### PR TITLE
clarify service config in DNS

### DIFF
--- a/A2-service-configs-in-dns.md
+++ b/A2-service-configs-in-dns.md
@@ -60,7 +60,7 @@ determine which choice will be selected by a given client:
     // All other numbers are considered invalid.
     "percentage": number,
     // Client hostname(s): a list of strings.  Each name is case 
-    // sensitive and must be an exact match as the hostname according to
+    // sensitive and must be an exact match of the hostname according to
     // the system.
     "clientHostname": [string],
 

--- a/A2-service-configs-in-dns.md
+++ b/A2-service-configs-in-dns.md
@@ -48,23 +48,37 @@ determine which choice will be selected by a given client:
     // Criteria used to select this choice.
     // If a field is absent or empty, it matches all clients.
     // All fields must match a client for this choice to be selected.
+    // If any unexpected field name is present in this object, the entire
+    // choice is considered invalid.
     //
     // Client language(s): a list of strings (e.g., "c++", "java", "go",
-    // "python", etc).
+    // "python", etc).  Each string is case insensitive.
     "clientLanguage": [string],
     // Percentage: integer from 0 to 100 indicating the percentage of
-    // clients that should use this choice.
+    // clients that should use this choice.  If present, the number must
+    // match the regular expression `^0|[0-9]|[1-9][0-9]|100$`
+    // All other numbers are considered invalid.
     "percentage": number,
-    // Client hostname(s): a list of strings.
+    // Client hostname(s): a list of strings.  Each name is case 
+    // sensitive and must be an exact match as the hostname according to
+    // the system.
     "clientHostname": [string],
 
     // The service config data object for clients that match the above
     // criteria.  (The format for this object is defined in
     // https://github.com/grpc/grpc/blob/master/doc/service_config.md.)
+    // If this field is not an object, or is missing, or is otherwise 
+    // invalid, this service config choice is considered invalid.
     "serviceConfig": object
   }
 ]
 ```
+
+If the service config choice cannot be parsed, or otherwise is not 
+semantically valid, it will be ignored.  Consumers of the service config
+SHOULD indicate when a config is not valid, but should not fail looking 
+for valid configs. 
+
 
 ### Encoding in DNS TXT Records
 

--- a/A2-service-configs-in-dns.md
+++ b/A2-service-configs-in-dns.md
@@ -4,7 +4,7 @@ Service Config via DNS
 * Approver: a11r
 * Status: Implemented
 * Implemented in: C-core (Go and Java in progress)
-* Last updated: 2017-11-10
+* Last updated: 2017-12-19
 * Discussion at: https://groups.google.com/d/topic/grpc-io/DkweyrWEXxU/discussion
 
 ## Abstract


### PR DESCRIPTION
The restrictions here do not affect that of the service config object contained in the choice.