### PR TITLE
Update ChannelTraceEvent::Severity enum

### DIFF
--- a/A3-channel-tracing.md
+++ b/A3-channel-tracing.md
@@ -61,6 +61,7 @@ message ChannelTraceEvent {
   string description = 1;
   // The supported severity levels of trace events.
   enum Severity {
+    UNKNOWN = 0;
     INFO = 1;
     WARNING = 2;
     ERROR = 3;


### PR DESCRIPTION
This is needed for the .proto to actually compile.

Realized while working on grpc/grpc#13883