### PR TITLE
L23 edit: add a synchronous proto loader function

### DIFF
--- a/L23-node-protobufjs-library.md
+++ b/L23-node-protobufjs-library.md
@@ -4,7 +4,7 @@ Standalone Node.js gRPC+Protobuf.js Library API
 * Approver: wenbozhu
 * Status: Ready for Implementation
 * Implemented in: Node.js
-* Last updated: 2018-01-30
+* Last updated: 2018-03-07
 * Discussion at: https://groups.google.com/forum/#!topic/grpc-io/t7XFE7Wevow
 
 ## Abstract
@@ -39,9 +39,17 @@ The library exposes the following function:
  * @return {Promise<PackageDefinition>} A promise for an object containing definitions for all of the loaded services
  */
 load(filename, options)
+
+/**
+ * Synchronously load a .proto file and all of its transitive imports
+ * @param {string} filename File path to the .proto file to load.
+ * @param {Object} options Options for loading the file and setting up the deserializers
+ * @return {PackageDefinition} A promise for an object containing definitions for all of the loaded services
+ */
+loadSync(filename, options)
 ```
 
-The `options` parameter of that function is the union of Protobuf.js's [`IParseOptions`](https://github.com/dcodeIO/protobuf.js/blob/cf7b26789f310dccf4c047c2e8ef5a3854f7f41e/index.d.ts#L1014) (which modifies how files are loaded) and [`IConversionOptions`](https://github.com/dcodeIO/protobuf.js/blob/cf7b26789f310dccf4c047c2e8ef5a3854f7f41e/index.d.ts#L1632) (which modifies deserialization functions), plus an `include` option to specify directories to search for dependencies. The full set of options is as follows:
+The `options` parameter of those functions is the union of Protobuf.js's [`IParseOptions`](https://github.com/dcodeIO/protobuf.js/blob/cf7b26789f310dccf4c047c2e8ef5a3854f7f41e/index.d.ts#L1014) (which modifies how files are loaded) and [`IConversionOptions`](https://github.com/dcodeIO/protobuf.js/blob/cf7b26789f310dccf4c047c2e8ef5a3854f7f41e/index.d.ts#L1632) (which modifies deserialization functions), plus an `include` option to specify directories to search for dependencies. The full set of options is as follows:
 
  - `keepCase`: a boolean indicating that field names should be preserved. The default is to change them to camel case.
  - `longs`: Can be set to `Number` or `String` to indicate that long values should be represented as that type. The default is `Number`, or a safer object `Long` type if the library is installed.


### PR DESCRIPTION
This was in the original proposal, but it was removed. Now I think it should be added again because a synchronous loader function is useful when a user needs to re-export objects derived from the loaded service information.