### PR TITLE
A14-channelz: rename to socket_ref for consistency in Subchannel

### DIFF
--- a/A14-channelz.md
+++ b/A14-channelz.md
@@ -692,7 +692,7 @@ message Subchannel {
   repeated SubchannelRef subchannel_ref = 4;
   
   // There are no ordering guarantees on the order of sockets.
-  repeated SocketRef socket = 5;
+  repeated SocketRef socket_ref = 5;
 }
 
 // These come from the specified states in this document:


### PR DESCRIPTION
The previous PR updated Channel but failed to update Subchannel.