### PR TITLE
Update A14-channelz.md to use RFC ciphersuite names

### DIFF
--- a/A14-channelz.md
+++ b/A14-channelz.md
@@ -879,10 +879,12 @@ message Address {
 
 message Security {
   message Tls {
-    // The key exchange used.  e.g. X25519
-    string key_exchange = 1;
-    // The cipher used. e.g. AES_128_GCM.
-    string cipher = 2;
+    // The cipher suite name in the RFC 4346 format:
+    // https://tools.ietf.org/html/rfc4346#appendix-C
+    string cipher_suite_standard_name = 1;
+    // Some other way to describe the cipher suite if
+    // the RFC 4346 name is not available.
+    string cipher_suite_other_name = 2;
     // the certificate used by this endpoint.
     bytes local_certificate = 3;
     // the certificate used by the remote endpoint.

--- a/A14-channelz.md
+++ b/A14-channelz.md
@@ -879,12 +879,14 @@ message Address {
 
 message Security {
   message Tls {
-    // The cipher suite name in the RFC 4346 format:
-    // https://tools.ietf.org/html/rfc4346#appendix-C
-    string cipher_suite_standard_name = 1;
-    // Some other way to describe the cipher suite if
-    // the RFC 4346 name is not available.
-    string cipher_suite_other_name = 2;
+    oneof cipher_suite {
+      // The cipher suite name in the RFC 4346 format:
+      // https://tools.ietf.org/html/rfc4346#appendix-C
+      string standard_name = 1;
+      // Some other way to describe the cipher suite if
+      // the RFC 4346 name is not available.
+      string other_name = 2;
+    }
     // the certificate used by this endpoint.
     bytes local_certificate = 3;
     // the certificate used by the remote endpoint.


### PR DESCRIPTION
The standard ciphersuite name already includes both the key exchange and the cipher. The naming convention is: `TLS_<key_exchange>_WITH_<cipher>_<hash>`:
https://tools.ietf.org/html/rfc4346#appendix-C

Just exposing the RFC name lets us avoid string parsing in every channelz implementation. It also exposes the hash algorithm for free.

I confirmed the Java SSL API provides an easy way to get this standard name. 

For C, there is https://www.openssl.org/docs/manmaster/man3/SSL_CIPHER_get_name.html:
> SSL_CIPHER_standard_name() returns a pointer to the standard RFC name of cipher. If the cipher is NULL, it returns "(NONE)". If the cipher has no standard name, it returns NULL. If cipher was defined in both SSLv3 and TLS, it returns the TLS name.

For Go:
https://golang.org/pkg/crypto/tls/#pkg-constants