### PR TITLE
Reference Java APIs for implemented proposals

### DIFF
--- a/A1-http-connect-proxy-support.md
+++ b/A1-http-connect-proxy-support.md
@@ -218,6 +218,13 @@ In Go, this functionality is being provided via a custom dialer:
 
 - [grpc/grpc-go#1098](https://github.com/grpc/grpc-go/pull/1098)
 
+In Java for case 1, Java's `java.net.ProxySelector` is observed and usable
+starting in v1.11.0. `ProxySelector` is generally configured with the Java
+defines `-Dhttps.proxyHost` and related. grpc-java supports HTTP Basic Proxy
+Authentication and credentials can be specified via the default
+`java.net.Authenticator`. The experimental `GRPC_PROXY_EXP=host:port`
+environment variable enabled limited proxy support starting in v1.0.3.
+
 ## Open issues (if applicable)
 
 N/A

--- a/A1-http-connect-proxy-support.md
+++ b/A1-http-connect-proxy-support.md
@@ -220,7 +220,7 @@ In Go, this functionality is being provided via a custom dialer:
 
 In Java for case 1, Java's `java.net.ProxySelector` is observed and usable
 starting in v1.11.0. `ProxySelector` is generally configured with the Java
-defines `-Dhttps.proxyHost` and related. grpc-java supports HTTP Basic Proxy
+properties `-Dhttps.proxyHost` and related. grpc-java supports HTTP Basic Proxy
 Authentication and credentials can be specified via the default
 `java.net.Authenticator`. The experimental `GRPC_PROXY_EXP=host:port`
 environment variable enabled limited proxy support starting in v1.0.3.

--- a/A8-client-side-keepalive.md
+++ b/A8-client-side-keepalive.md
@@ -249,5 +249,5 @@ abusive usage of TCP keepalive.
     `keepAliveWithoutCalls()`.
   * The server options can be specified via
     `NettyServerBuilder.permitKeepAliveTime()` and
-    `permitKeepAliveWithoutCalls`.
+    `permitKeepAliveWithoutCalls()`.
 * Go. TODO get current progress; close, if not done. Being done by @MakMukhi

--- a/A8-client-side-keepalive.md
+++ b/A8-client-side-keepalive.md
@@ -244,4 +244,10 @@ abusive usage of TCP keepalive.
 * Java. Basic Keepalive has been available in OkHttp transport since 1.0 by
   @zsurocking in grpc/grpc-java#1992. Full spec completed in OkHttp and Netty
   since grpc-java v1.3.0 or grpc/grpc-java@393ebf7c
+  * The client options can be specified via
+    `ManagedChannelBuilder.keepAliveTime()`, `keepAliveTimeout()`, and
+    `keepAliveWithoutCalls()`.
+  * The server options can be specified via
+    `NettyServerBuilder.permitKeepAliveTime()` and
+    `permitKeepAliveWithoutCalls`.
 * Go. TODO get current progress; close, if not done. Being done by @MakMukhi

--- a/A9-server-side-conn-mgt.md
+++ b/A9-server-side-conn-mgt.md
@@ -116,6 +116,6 @@ connections with few RPCs on them.
 * C. TODO get current progress; close, if not done. Being done by @y-zeng
 * Java. Complete since grpc/grpc-java@4a96e259 in v1.4.0. Bug fix in v1.7.1.
   * The options can be specified via `NettyServerBuilder.maxConnectionIdle()`,
-    `maxConnectionAge()`, `maxConnectionAgeGrace`, `keepAliveTime()`, and
+    `maxConnectionAge()`, `maxConnectionAgeGrace()`, `keepAliveTime()`, and
     `keepAliveTimeout()`.
 * Go. TODO get current progress; close, if not done. Being done by @MakMukhi

--- a/A9-server-side-conn-mgt.md
+++ b/A9-server-side-conn-mgt.md
@@ -114,5 +114,8 @@ connections with few RPCs on them.
 ## Implementation
 
 * C. TODO get current progress; close, if not done. Being done by @y-zeng
-* Java. Complete since grpc/grpc-java@4a96e259
+* Java. Complete since grpc/grpc-java@4a96e259 in v1.4.0. Bug fix in v1.7.1.
+  * The options can be specified via `NettyServerBuilder.maxConnectionIdle()`,
+    `maxConnectionAge()`, `maxConnectionAgeGrace`, `keepAliveTime()`, and
+    `keepAliveTimeout()`.
 * Go. TODO get current progress; close, if not done. Being done by @MakMukhi


### PR DESCRIPTION
@MakMukhi, @vjpai, could you help get similar changes in place for A8 and A9? Note that C probably needs to explicitly state the mapping from each spec-defined option; I sort of expect it wouldn't be obvious just given the option names.

CC @markdroth, @zpencer 