### PR TITLE
A6-client-retries: minor clarifications and define a maximum value for maxTokens

### DIFF
--- a/A6-client-retries.md
+++ b/A6-client-retries.md
@@ -198,15 +198,15 @@ There are five possible types of server responses. The list below enumerates the
     1. Retry policy: Successful response, return success to client application
     2. Hedging policy: Successful response, cancel previous and pending hedges
 
-2. Retryable/Non-Fatal Status Code
-    1. Retry policy: Retry according to policy
-    2. Hedging policy: Immediately send next scheduled hedged request, if any. Subsequent hedged requests will resume at `hedgingDelay`
-
-3. Fatal Status Code
+2. Fatal Status Code
     1. Retry policy: Don't retry, return failure to client application
     2. Hedging policy: Cancel previous and pending hedges
 
-4. Pushback: Don't retry
+3. Retryable/Non-Fatal Status Code without Server Pushback
+    1. Retry policy: Retry according to policy
+    2. Hedging policy: Immediately send next scheduled hedged request, if any. Subsequent hedged requests will resume at `hedgingDelay`
+
+4. Pushback: Don't Retry
     1. Retry policy: Don't retry, return failure to client application
     2. Hedging policy: Don’t send any more hedged requests.
 

--- a/A6-client-retries.md
+++ b/A6-client-retries.md
@@ -483,7 +483,8 @@ The retry policy is transmitted to the client through the service config mechani
     // The number of tokens starts at maxTokens. The token_count will always be
     // between 0 and maxTokens.
     //
-    // This field is required and must be greater than zero.
+    // This field is required and must be in the range (0, 1000].  Up to 3
+    // decimal places are supported
     "maxTokens": number,
 
     // The amount of tokens to add on each successful RPC. Typically this will


### PR DESCRIPTION
The maximum value for `maxTokens` is obviously open for debate.  This was just a value I chose randomly that seemed like more than most people would want to use.