### PR TITLE
L42 Surface 'wait-for-ready' setting in Python client

### DIFF
--- a/L42-metadata-flags.md
+++ b/L42-metadata-flags.md
@@ -1,4 +1,4 @@
-Title
+Utilize Metadata Flags -- Adding "Wait For Ready" Semantics
 ----
 * Author(s): lidizheng
 * Approver: a11r

--- a/L42-metadata-flags.md
+++ b/L42-metadata-flags.md
@@ -1,0 +1,104 @@
+Title
+----
+* Author(s): lidizheng
+* Approver: a11r
+* Status: Draft
+* Implemented in: Python
+* Last updated: October 16, 2018
+* Discussion at: <google group thread> (filled after thread exists)
+
+## Abstract
+
+Enable gRPC Python client to utilize the “Wait For Ready” mechanism provided by C-Core, which underlying is to utilize the initial metadata flags. This mechanism can later be used to support future metadata flags.
+
+## Background
+
+### Definition of “Wait For Ready” semantics
+> If an RPC is issued but the channel is in TRANSIENT_FAILURE or SHUTDOWN states, the RPC is unable to be transmitted promptly. By default, gRPC implementations SHOULD fail such RPCs immediately. This is known as "fail fast," but the usage of the term is historical. RPCs SHOULD NOT fail as a result of the channel being in other states (CONNECTING, READY, or IDLE).
+> 
+> gRPC implementations MAY provide a per-RPC option to not fail RPCs as a result of the channel being in TRANSIENT_FAILURE state. Instead, the implementation queues the RPCs until the channel is READY. This is known as "wait for ready." The RPCs SHOULD still fail before READY if there are unrelated reasons, such as the channel is SHUTDOWN or the RPC's deadline is reached.
+> 
+> From https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md 
+
+### Use cases for “Wait For Ready”
+
+When developers spin up gRPC clients and servers in the same time, it is very like to fail first couple RPC calls due to unavailability of the server. If developers failed to prepare for this situation, the result can be catastrophic. But with “Wait For Ready” semantics, developers can initialize the client and server in any order, especially useful in testing.
+
+Also, developers may ensure the server is up before starting client. But in some cases like transient network failure may result in a temporary unavailability of the server. With “Wait For Ready” semantics, those RPC calls will automatically wait until the server is ready to accept incoming requests.
+
+### Current "Wait For Ready" behavior
+
+After the channel instance is instantiated, it will attempt to connect to the server. Even if the connection attempt is failed, the gRPC client won’t be blocked. If the first connection attempt failed, any gRPC requests immediately after will fail with StatusCode.UNAVAILABLE.
+
+But there is a Python-only function to simulate the “Wait For Ready” mechanism. It is a class named `_ChannelReadyFuture` in `_utilities.py`. It will create a `Future` object to enable the client to block till the channel is ready. It works just like the “Wait For Ready” mechanism with Pythonic handling approach, but it has three drawbacks:
+
+1. Usage is different from other languages like C++, Golang, Java. It may create inconsistency usage across language and additional cognitive cost for migrating from/to Python.
+1. Considered technical debt. More than 100 lines of code implementing the same function which C-Core already provided.
+1. It only account for the first connection attempt. Instead, C-Core “Wait For Ready” mechanism allows every RPC call to be blocked if server is unavailable.
+
+Strictly speaking, the `_ChannelReadyFuture` works in most cases. And it is already used in many Google internal projects. So this interface has to be maintained in the near future.
+
+### Desired “Wait For Ready” behavior
+After setting “Wait For Ready” option to the channel construction method, the channel will automatically enable this mechanism for all the outgoing RPC calls. NOT only the first one. This usage will be consistent with other language’s implementation.
+
+Also, by adding per RPC variable, the client can customize each RPC call to leverage the “Wait For Ready” mechanism. This can give Python a little advantage over other languages.
+
+### The 2-bits 3-states switch of “Wait For Ready”
+The implementation of “Wait For Ready” flags is not as simple as a one bit switch. It contains two bits one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY` another one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY_EXPLICITLY_SET`. Although two bits can represent four states, three of them are valid.
+
+Assume `flag` is the flag variable we are manipulating.
+
+If the developer wants to use default value, then `flag = flag & ~WAIT_FOR_READY & ~WAIT_FOR_READY_EXPLICITLY_SET` (both 0).
+
+If the developer doesn't want to "wait for ready", then `flag = flag & ~WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (0, 1).
+
+If the developer wants to "wait for ready", then `flag = flag & WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (1, 1).
+
+### Related Proposals: 
+
+N/A
+
+## Proposal
+
+* Add an optional `wait_for_ready` variable to `Channel` class initialization method. Default `None`, accept `bool`.
+* Add an optional `wait_for_ready` variable to `MultiCallable` classes initialization methods. Default `None`, accept `bool`.
+* Use a new private member variable in `Channel` class to held `initial_metadata_flags`.
+* Per RPC level `wait_for_ready` variable can override upper level.
+* Import initial metadata flags constants from `grpc_types.h` to `grpc.pxi`.
+
+## Rationale
+
+### Separate variable vs. Add an option
+* Separate variable provides easy-to-use interface; just add an option can be done quickly and remove easily if needed.
+* Another problem is currently `Channel Args` or `options` are in the form of `tuple(<key>, <value>)` which is not exactly suit for flags-like variable
+* Also, the explosion of variables won't be a concern because other high level APIs won't be ready to expose in near future. Besides, optional API in Python can be ignored to keep program simple.
+* That's why using a separate variable is better.
+
+### Why not integrate with `_channel_managed_call_management`?
+* Currently, we have a `managed_call` mechanism which works similar to call context in other languages.
+* It doesn’t work properly with flags.
+* It just pass a hardcoded `0` every time
+* It only be called for asynchronous calls. 
+* I prefer to implement it separately, with another private member variable.
+
+
+## Implementation
+
+Please refer to PR #TODO
+
+### Testing Plan
+The testing will be similar to the unit test of _ChannelReadyFuture. It will contain three parts:
+
+1. Validate the options are set properly, and make sure the C-Core receives correct flags.
+2. Validate the behavior of client failed connect to an unexisting server without “Wait For Ready” option.
+1. Validate the behavior of client successfully connect to a later-spawned server with “Wait For Ready” option.
+
+### “Wait For Ready” doesn’t cover all UNAVAILABLE status.
+As mentioned in the definition, during my experiments, the “Wait For Ready” works to handle “Connect Failed” but not “Socket Closed”, which means if the server crashes while handling a request, the request will still be failed without retry or wait.
+
+This behavior makes sense if the request is not idempotent, then it is possible that the server starts to handle the request and conduct some write operation to databases already. In this special cases, developers need to solve failed requests themselves.
+
+
+## Open issues
+
+* Issue #6770

--- a/L42-metadata-flags.md
+++ b/L42-metadata-flags.md
@@ -121,7 +121,7 @@ stub.important_transaction_4(...)
 
 ## Implementation
 
-Please refer to PR #16915
+Please refer to PR #16919
 
 ### Testing Plan
 The testing will be similar to the unit test of _ChannelReadyFuture. It will contain three parts:

--- a/L42-metadata-flags.md
+++ b/L42-metadata-flags.md
@@ -5,7 +5,7 @@ Utilize Metadata Flags -- Adding "Wait For Ready" Semantics
 * Status: Draft
 * Implemented in: Python
 * Last updated: October 16, 2018
-* Discussion at: <google group thread> (filled after thread exists)
+* Discussion at: https://groups.google.com/forum/#!topic/grpc-io/Q6fgbn0RZLs
 
 ## Abstract
 

--- a/L42-metadata-flags.md
+++ b/L42-metadata-flags.md
@@ -1,4 +1,4 @@
-Utilize Metadata Flags -- Adding "Wait For Ready" Semantics
+Surface 'wait-for-ready' setting in Python client
 ----
 * Author(s): lidizheng
 * Approver: a11r
@@ -9,50 +9,52 @@ Utilize Metadata Flags -- Adding "Wait For Ready" Semantics
 
 ## Abstract
 
-Enable gRPC Python client to utilize the “Wait For Ready” mechanism provided by C-Core, which underlying is to utilize the initial metadata flags. This mechanism can later be used to support future metadata flags.
+Surface 'wait-for-ready' configuration in gRPC Python client that will use the mechanism provided by C-Core via the initial metadata flags. The implementation should allow adding future such configurations in gRPC Python easily.
 
 ## Background
 
-### Definition of “Wait For Ready” semantics
+### Definition of 'wait-for-ready' semantics
 > If an RPC is issued but the channel is in TRANSIENT_FAILURE or SHUTDOWN states, the RPC is unable to be transmitted promptly. By default, gRPC implementations SHOULD fail such RPCs immediately. This is known as "fail fast," but the usage of the term is historical. RPCs SHOULD NOT fail as a result of the channel being in other states (CONNECTING, READY, or IDLE).
 > 
 > gRPC implementations MAY provide a per-RPC option to not fail RPCs as a result of the channel being in TRANSIENT_FAILURE state. Instead, the implementation queues the RPCs until the channel is READY. This is known as "wait for ready." The RPCs SHOULD still fail before READY if there are unrelated reasons, such as the channel is SHUTDOWN or the RPC's deadline is reached.
 > 
 > From https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md 
 
-### Use cases for “Wait For Ready”
+### Use cases for 'wait-for-ready'
 
-When developers spin up gRPC clients and servers in the same time, it is very like to fail first couple RPC calls due to unavailability of the server. If developers failed to prepare for this situation, the result can be catastrophic. But with “Wait For Ready” semantics, developers can initialize the client and server in any order, especially useful in testing.
+When developers spin up gRPC clients and servers in the same time, it is very like to fail first couple RPC calls due to unavailability of the server. If developers failed to prepare for this situation, the result can be catastrophic. But with 'wait-for-ready' semantics, developers can initialize the client and server in any order, especially useful in testing.
 
-Also, developers may ensure the server is up before starting client. But in some cases like transient network failure may result in a temporary unavailability of the server. With “Wait For Ready” semantics, those RPC calls will automatically wait until the server is ready to accept incoming requests.
+Also, developers may ensure the server is up before starting client. But in some cases like transient network failure may result in a temporary unavailability of the server. With 'wait-for-ready' semantics, those RPC calls will automatically wait until the server is ready to accept incoming requests.
 
-### Current "Wait For Ready" behavior
+### Current 'wait-for-ready' behavior
 
-After the channel instance is instantiated, it will attempt to connect to the server. Even if the connection attempt is failed, the gRPC client won’t be blocked. If the first connection attempt failed, any gRPC requests immediately after will fail with StatusCode.UNAVAILABLE.
+By default, the client RPC call will fail immediately if the server is unavailable.
 
-But there is a Python-only function to simulate the “Wait For Ready” mechanism. It is a class named `_ChannelReadyFuture` in `_utilities.py`. It will create a `Future` object to enable the client to block till the channel is ready. It works just like the “Wait For Ready” mechanism with Pythonic handling approach, but it has three drawbacks:
+But there is a Python-only function to simulate the 'wait-for-ready' mechanism. It is a class named `_ChannelReadyFuture` in `_utilities.py`. It will create a `Future` object to enable the client to block till the channel is ready. It works just like the 'wait-for-ready' mechanism with Pythonic handling approach, but it has three drawbacks:
 
-1. Usage is different from other languages like C++, Golang, Java. It may create inconsistency usage across language and additional cognitive cost for migrating from/to Python.
-1. Considered technical debt. More than 100 lines of code implementing the same function which C-Core already provided.
-1. It only account for the first connection attempt. Instead, C-Core “Wait For Ready” mechanism allows every RPC call to be blocked if server is unavailable.
+1. Usage is different from other languages like C++, Golang, Java. It may create inconsistent usage across language and additional cognitive cost for migrating from/to Python.
+2. Considered technical debt. More than 100 lines of code implementing the same function which C-Core already provided.
+3. It only account for the first connection attempt. Instead, C-Core 'wait-for-ready' mechanism allows every RPC call to be blocked if server is unavailable.
 
-Strictly speaking, the `_ChannelReadyFuture` works in most cases. And it is already used in many Google internal projects. So this interface has to be maintained in the near future.
+Strictly speaking, the `_ChannelReadyFuture` works in most cases. Though it is fungible to 'wait-for-ready', this interface has to be maintained in the near future.
 
-### Desired “Wait For Ready” behavior
-After setting “Wait For Ready” option to the channel construction method, the channel will automatically enable this mechanism for all the outgoing RPC calls. NOT only the first one. This usage will be consistent with other language’s implementation.
+### Desired 'wait-for-ready' behavior
 
-Also, by adding per RPC variable, the client can customize each RPC call to leverage the “Wait For Ready” mechanism. This can give Python a little advantage over other languages.
+The desired behavior will be able to config each RPC call with different settings. Currently, Python is using keyword argument for call level configuration, so this feature will use keyword argument as well. The keyword argument mechanism also enables developers to configure certain calls with one setting in many ways (like expand a dictionary-like object every time).
 
-### The 3-states switch of “Wait For Ready” in C-Core
-The implementation of “Wait For Ready” flags is not as simple as a one bit switch. It contains two bits one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY` another one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY_EXPLICITLY_SET`. Although two bits can represent four states, three of them are valid.
+In other languages, there is a few difference in implementation. They prefer to have a separate class for call configuration ('ClientContext' in C++, 'CallOptions' in Java & Go), then pass it to every RPC invocation. The new design can be equivalence in behavior.
+
+### The 3-states switch of 'wait-for-ready' in C-Core
+
+The implementation of 'wait-for-ready' flags is not as simple as a one bit switch. It contains two bits one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY` another one is `GRPC_INITIAL_METADATA_WAIT_FOR_READY_EXPLICITLY_SET`. Although two bits can represent four states, three of them are valid.
 
 Assume `flag` is the flag variable we are manipulating.
 
 If the developer wants to use default value, then `flag = flag & ~WAIT_FOR_READY & ~WAIT_FOR_READY_EXPLICITLY_SET` (both 0).
 
-If the developer doesn't want to "wait for ready", then `flag = flag & ~WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (0, 1).
+If the developer doesn't want to 'wait-for-ready', then `flag = flag & ~WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (0, 1).
 
-If the developer wants to "wait for ready", then `flag = flag & WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (1, 1).
+If the developer wants to 'wait-for-ready', then `flag = flag & WAIT_FOR_READY & WAIT_FOR_READY_EXPLICITLY_SET` (1, 1).
 
 ### Related Proposals: 
 
@@ -61,9 +63,7 @@ N/A
 ## Proposal
 
 * Add an optional `wait_for_ready` variable to `MultiCallable` classes initialization methods. Default `None`, accept `bool`.
-* Per RPC level `wait_for_ready` variable can override upper level.
 * Import initial metadata flags constants from `grpc_types.h` to `grpc.pxi`.
-* (Suggesting) Add an optional `wait_for_ready` variable to `Channel` class initialization method. Default `None`, accept `bool`.
 
 ### DEMO snippets 
 
@@ -100,17 +100,13 @@ stub.important_transaction_4(...)
 * The channel level variable is convenient and Pythonic
 * But it may create extra burden for future API evolution
 * **Please** comment about whether you feel like this design works for you or not
-
-### Separate variable vs. Add an option
-* Separate variable provides easy-to-use interface; just add an option can be done quickly and remove easily if needed.
-* Another problem is currently `Channel Args` or `options` are in the form of `tuple(<key>, <value>)` which is not exactly suit for flags-like variable
-* Also, the explosion of variables won't be a concern because other high level APIs won't be ready to expose in near future. Besides, optional API in Python can be ignored to keep program simple.
-* That's why using a separate variable is better.
+* > Users "pay" for the complexity even if they don't use the feature.  --Eric Anderson
+* > We should be conservative when adding APIs, as we can easily add but cannot remove APIs. --Mehrdad Afshari
 
 ### Why not integrate with `_channel_managed_call_management`?
 * Currently, we have a `managed_call` mechanism which works similar to call context in other languages.
 * It doesn’t work properly with flags.
-* It just pass a hardcoded `0` every time
+* It just pass a hard-coded `0` every time
 * It only be called for asynchronous calls. 
 * I prefer to implement it separately, with another private member variable.
 
@@ -127,11 +123,11 @@ Please refer to PR #16919
 The testing will be similar to the unit test of _ChannelReadyFuture. It will contain three parts:
 
 1. Validate the options are set properly, and make sure the C-Core receives correct flags.
-2. Validate the behavior of client failed connect to an unexisting server without “Wait For Ready” option.
-3. Validate the behavior of client successfully connect to a later-spawned server with “Wait For Ready” option.
+2. Validate the behavior of client failed connect to an non-existing server without 'wait-for-ready' option.
+3. Validate the behavior of client successfully connect to a later-spawned server with 'wait-for-ready' option.
 
-### “Wait For Ready” doesn’t cover all UNAVAILABLE status.
-As mentioned in the definition, during my experiments, the “Wait For Ready” works to handle “Connect Failed” but not “Socket Closed”, which means if the server crashes while handling a request, the request will still be failed without retry or wait.
+### 'wait-for-ready' doesn’t cover all UNAVAILABLE status.
+As mentioned in the definition, during my experiments, the 'wait-for-ready' works to handle 'wait-for-ready' not 'wait-for-ready' which means if the server crashes while handling a request, the request will still be failed without retry or wait.
 
 This behavior makes sense if the request is not idempotent, then it is possible that the server starts to handle the request and conduct some write operation to databases already. In this special cases, developers need to solve failed requests themselves.
 

--- a/L42-python-metadata-flags.md
+++ b/L42-python-metadata-flags.md
@@ -80,7 +80,21 @@ stub.unimportant_transaction_4(...)
 ```
 
 ```Python
-# Channel level
+# Per RPC level with configuration for subsets
+stub = ...Stub(...)
+
+important_call_options = {'wait_for_ready': True, 'timeout': 4000}
+failfast_call_options = {'wait_for_ready': False}
+
+stub.initial_rpc_call(..., **important_call_options)
+stub.important_transaction_1(..., **important_call_options)
+stub.unimportant_transaction_2(..., **failfast_call_options)
+stub.important_transaction_3(..., **important_call_options)
+stub.unimportant_transaction_4(..., **failfast_call_options)
+```
+
+```Python
+# Channel level - Invalid Design
 channel = grpc.insecure_channel(..., wait_for_ready=True)
 stub = ...Stub(channel)
 

--- a/L42-python-metadata-flags.md
+++ b/L42-python-metadata-flags.md
@@ -93,6 +93,8 @@ stub.important_transaction_3(..., **important_call_options)
 stub.unimportant_transaction_4(..., **failfast_call_options)
 ```
 
+### Unsupported Design
+
 ```Python
 # Channel level - Invalid Design
 channel = grpc.insecure_channel(..., wait_for_ready=True)
@@ -100,8 +102,9 @@ stub = ...Stub(channel)
 
 stub.important_transaction_1(...)
 stub.important_transaction_2(...)
-stub.unimportant_transaction_3(...) # This will wait as well
-stub.important_transaction_4(...)
+stub.unimportant_transaction_3(...) # This will wait as well; user might get confused
+# --- A lot of code here ---
+stub.yet_another_transaction_500(...) # User might forget the channel setting
 ```
 
 ## Rationale

--- a/L42-python-metadata-flags.md
+++ b/L42-python-metadata-flags.md
@@ -30,7 +30,7 @@ Also, developers may ensure the server is up before starting client. But in some
 
 By default, the client RPC call will fail immediately if the server is unavailable.
 
-But there is a Python-only function to simulate the 'wait-for-ready' mechanism. It is a class named `_ChannelReadyFuture` in `_utilities.py`. It will create a `Future` object to enable the client to block till the channel is ready. It works just like the 'wait-for-ready' mechanism with Pythonic handling approach, but it has three drawbacks:
+But there is a Python-only function to simulate the 'wait-for-ready' mechanism. It is a class named `_ChannelReadyFuture` in `_utilities.py`. It will create a `Future` object to enable the client to block till the channel is ready. It works similarly to the 'wait-for-ready' mechanism with Pythonic handling approach, but it has three drawbacks:
 
 1. Usage is different from other languages like C++, Golang, Java. It may create inconsistent usage across language and additional cognitive cost for migrating from/to Python.
 2. Considered technical debt. More than 100 lines of code implementing the same function which C-Core already provided.

--- a/L42-python-metadata-flags.md
+++ b/L42-python-metadata-flags.md
@@ -1,8 +1,8 @@
 Surface 'wait-for-ready' setting in Python client
 ----
 * Author(s): lidizheng
-* Approver: a11r
-* Status: Draft
+* Approver: srini100
+* Status: In Review
 * Implemented in: Python
 * Last updated: October 16, 2018
 * Discussion at: https://groups.google.com/forum/#!topic/grpc-io/Q6fgbn0RZLs


### PR DESCRIPTION
Please view the gRFC at https://github.com/lidizheng/proposal/blob/master/L42-python-metadata-flags.md

PR: https://github.com/grpc/grpc/pull/16919
Issue: https://github.com/grpc/grpc/issues/6770