### PR TITLE
Update example json string in LB Policy Config

### DIFF
--- a/A24-lb-policy-config.md
+++ b/A24-lb-policy-config.md
@@ -158,15 +158,19 @@ In JSON form (which is what is actually used in gRPC core), it would
 look like this:
 
 ```json
-{"loadBalancingConfig":
-  [
-    {"xds": {
-      "balancerName": "dns:///balancer.example.com:8080",
-      "childPolicy": {
-        "round_robin": {}
+{
+   "loadBalancingConfig":[
+      {
+         "xds":{
+            "balancerName":"dns:///balancer.example.com:8080",
+            "childPolicy":[
+               {
+                  "round_robin":{}
+               }
+            ]
+         }
       }
-    }}
-  ]
+   ]
 }
 ```
 


### PR DESCRIPTION
Recent change (#120) made the childPolicy and fallbackPolicy fields to be repeated. Thus the corresponding json string should have square brackets to indicate JSON array.