### PR TITLE
Clarify specification of percentage selector in service configs in DNS.

### DIFF
--- a/A2-service-configs-in-dns.md
+++ b/A2-service-configs-in-dns.md
@@ -55,9 +55,12 @@ determine which choice will be selected by a given client:
     // "python", etc).  Each string is case insensitive.
     "clientLanguage": [string],
     // Percentage: integer from 0 to 100 indicating the percentage of
-    // clients that should use this choice.  If present, the number must
-    // match the regular expression `^0|[0-9]|[1-9][0-9]|100$`
-    // All other numbers are considered invalid.
+    // clients that should use this choice.  Each client's resolver should
+    // compute its percentage at startup and use the same percentage for the
+    // lifetime of the resolver; if the client's computed percentage is less
+    // than the value of this field, then it is considered a match.
+    // If present, the number must match the regular expression
+    // `^0|[0-9]|[1-9][0-9]|100$`.  All other values are considered invalid.
     "percentage": number,
     // Client hostname(s): a list of strings.  Each name is case 
     // sensitive and must be an exact match of the hostname according to


### PR DESCRIPTION
It looks like our current implementations are all doing the wrong thing with the percentage selector: we are actually recomputing the client's random percentage for each choice we evaluate when parsing the service config choices, which means (a) we may not have a consistent value when there are multiple choices with different percentage values and (b) even worse, we will recompute the percentage every time the resolver re-resolves, which means we will wind up switching configs whenever (e.g.) a subchannel becomes disconnected.

I am proposing that the client compute its percentage at resolver startup and retain it for the lifetime of the resolver.  This means that if a client starts up and computes a low percentage for itself, it will wind up being an early canary, but I think that's okay.

The alternative would be to have the resolver check whether the service config has changed since the last resolution and recompute the client's percentage only if it has changed.  However, this would actually make it harder to understand what's happening when the service owner is canarying changes, because it would be much harder to identify which clients are getting the canary config.