### PR TITLE
L59 - Allow C++ standard library in gRPC Core Library

### DIFF
--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -1,0 +1,97 @@
+Allow C++ standard library in gRPC Core Library
+----
+* Author(s): veblush
+* Approver: a11r
+* Status: Draft
+* Implemented in: n/a
+* Last updated: August 19, 2019
+* Discussion at: <TBD>
+
+## Abstract
+
+Allow C++ Standard Library to be used in the gRPC Core library.
+
+## Background
+
+Since C++ was allowed to write gRPC, more and more code has been written in C++.
+But most features from C++ standard libraries were not allowed to use because
+we didn't want to introduce new dependency against C++ standard library.
+This gRFC proposes allowing C++ standard library to be used within the core
+library, but continues to restrict the public interface to C89.
+
+### Related Proposals:
+
+* [Allow C++ in gRPC Core Library](L6-core-allow-cpp.md)
+
+## Proposal
+
+Allow C++11 standard library usage in gRPC Core. The previous C++ usage rule
+will be valid except the restriction on C++ features and header-only library.
+
+- All C++11 features are allowed to use. Followings were not possible to use
+  but it becomes availabie with this.
+  - `new` and `delete`
+    - Even though `new` and `delete` now become possible to use, it doesn't
+      necessarilly mean that all code should use.
+      For the place where `gpr_malloc` and `gpr_free` should be used
+      intentionally, `grpc_core::New` and `grpc_core::Delete` need to be
+      used.
+  - Pure virtual functions.
+    Regular form `= 0` can be used instead of `GRPC_ABSTRACT`
+
+- All features from C++11 standard library are allowed to use.
+  Previosuly only header-only features were allowed to use.
+
+There are caveats since gRPC wrapped library are being distributed as a binary
+form and still there are many old but active linux distributions which don't
+have full C++11 standard library.
+
+- Only features from C++ standard library available on
+  [manylinux1](https://www.python.org/dev/peps/pep-0513)
+  can be allowed to use. It sounds a bit disappointing but most of essential
+  features in C++ standard library are available in `manylinux1`.
+  Following is a partial list of missing features because of `manylinux1`.
+  - std::chrono.
+  - std::numeric_limits for long long and some methods.
+  - string and stream support for wchar_t.
+  - new implementation of string and list compliant with C++11.
+    (still old implementation of string and list are available)
+
+## Rationale
+
+Using C++ standard library gives us several advantages:
+- gRPC Core can use all useful and essential classes in C++ standard library.
+  This allows us not to reinvent everything which are already available.
+- gRPC Core can use other libraries which requires C++ standard library.
+  Previously linking to abseil or protobuf was impossible because it requires C++
+  standard library. With this, we can consider it.
+
+All previous restrictions not to link the library are arbitrary and it can
+change anytime because it's not part of standard or specification but
+implementation details. Having gRPC built by `gcc` and `libstdc++` doesn't
+guarantee that it can achieve the same goal with `clang` and `libc++`.
+
+## Implementation
+
+1. Change build configuration for all wrapped language to add the dependency
+   to C++ standard library.
+2. Make changes to use C++ standard library to prove it's working.
+   At the same time, it should be small enough so that they are easily
+   rolled back just in case
+   - Replace `grpc_core::map` with `std::map`
+   - Replace `GRPC_ABSTRACT` with `= 0`
+3. Add new build tests to make sure that the version of library gRPC uses
+   is old enough for most platforms to have it.
+   - For Python and Ruby, manylinux1 is a good candidate to target.
+
+## Schedule
+
+1. New dependency against the C++ standard library is added with
+   some code depending it. This has to be easily rolled back just in case.
+   -> Target gRPC 1.25 (schedulled on October 22, 2019)
+2. Once this version looks fine, all gRPC Core now is allowed to use the library.
+   -> From gRPC 1.26-dev
+
+## Open issues (if applicable)
+
+- Platform reach may decrease, but we feel this will not be significant.

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -16,8 +16,15 @@ Allow C++ Standard Library to be used in the gRPC Core library.
 Since C++ was allowed to write gRPC, more and more code has been written in C++.
 But most features from C++ standard libraries were not allowed to use because
 we didn't want to introduce new dependency against C++ standard library.
-This gRFC proposes allowing C++ standard library to be used within the core
-library, but continues to restrict the public interface to C89.
+
+The decision to use C++ has been helping us to be more productive but it's not
+best because we cannot use C++ standard library and a few of C++ features which
+depend on this. This also prevents us from using other C++ library which rely 
+on the library. (e.g. abseil)
+
+This gRFC proposes allowing C++ standard library to be used within the gRPC 
+Core library. It may free us from reinventing wheels which already exists
+in the standard library and help us become more productive.
 
 ### Related Proposals:
 
@@ -43,14 +50,32 @@ will be valid except the restriction on C++ features and header-only library.
   Previously only header-only features were allowed to use.
 
 There are caveats since gRPC wrapped library are being distributed as a binary
-form and still there are many old but active Linux distributions which don't
-have full C++11 standard library.
+form. Wrapped library includes a gRPC Core artifact so this change affects
+all wrapped libraries and C++ standard library should be installed to make
+wrapped gRPC library work properly.
 
-- Only features from C++ standard library available on
-  [manylinux1](https://www.python.org/dev/peps/pep-0513)
-  can be allowed to use. It sounds a bit disappointing but most of essential
-  features in C++ standard library are available in `manylinux1`.
-  Following is a partial list of missing features because of `manylinux1`.
+Goal is to try not to ask users to install additional C++ standard library
+if possible. Solution varies depending on each platform.
+
+ - Linux: Uses the same restriction from 
+    [manylinux1](https://www.python.org/dev/peps/pep-0513) policy
+    because it targets old enough Linux.
+ - Windows: Since Windows hasn't been bundled with C++ library,
+    gRPC has been linked to C++ standard library in a static way.
+    So this change doesn't affect Windows.
+ - MacOS/iOS/Android: Since a specific version of C++ library has been
+    distributed on these platforms, 
+    users don't need to worry about this.
+
+Simply speaking, we can use C++11 library features which are available
+in `manylinux1`. For details on `manylinux`, you can see the 
+[doc](https://www.python.org/dev/peps/pep-0513).
+Here is what matters to C++.
+
+  - GLIBCXX <= 3.4.9 (GCC 4.2.0)
+
+Fortunately, most of C++ standrad library availble on this restriction.
+Following is a partial list of missing features because of `manylinux1`.
   - std::chrono.
   - std::numeric_limits for long long and some methods.
   - string and stream support for wchar_t.

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -2,7 +2,7 @@ Allow C++ standard library in gRPC Core Library
 ----
 * Author(s): veblush
 * Approver: a11r
-* Status: Draft
+* Status: Final
 * Implemented in: n/a
 * Last updated: September 4, 2019
 * Discussion at: https://groups.google.com/forum/#!topic/grpc-io/umQyyXmNr2w

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -29,10 +29,10 @@ Allow C++11 standard library usage in gRPC Core. The previous C++ usage rule
 will be valid except the restriction on C++ features and header-only library.
 
 - All C++11 features are allowed to use. Followings were not possible to use
-  but it becomes availabie with this.
+  but it becomes available with this.
   - `new` and `delete`
     - Even though `new` and `delete` now become possible to use, it doesn't
-      necessarilly mean that all code should use.
+      necessarily mean that all code should use.
       For the place where `gpr_malloc` and `gpr_free` should be used
       intentionally, `grpc_core::New` and `grpc_core::Delete` need to be
       used.
@@ -40,10 +40,10 @@ will be valid except the restriction on C++ features and header-only library.
     Regular form `= 0` can be used instead of `GRPC_ABSTRACT`
 
 - All features from C++11 standard library are allowed to use.
-  Previosuly only header-only features were allowed to use.
+  Previously only header-only features were allowed to use.
 
 There are caveats since gRPC wrapped library are being distributed as a binary
-form and still there are many old but active linux distributions which don't
+form and still there are many old but active Linux distributions which don't
 have full C++11 standard library.
 
 - Only features from C++ standard library available on
@@ -88,7 +88,7 @@ guarantee that it can achieve the same goal with `clang` and `libc++`.
 
 1. New dependency against the C++ standard library is added with
    some code depending it. This has to be easily rolled back just in case.
-   -> Target gRPC 1.25 (schedulled on October 22, 2019)
+   -> Target gRPC 1.25 (scheduled on October 22, 2019)
 2. Once this version looks fine, all gRPC Core now is allowed to use the library.
    -> From gRPC 1.26-dev
 

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -13,14 +13,13 @@ Allow C++ Standard Library to be used in the gRPC Core library.
 
 ## Background
 
-Since C++ was allowed to write gRPC, more and more code has been written in C++.
-But most features from C++ standard libraries were not allowed to use because
-we didn't want to introduce new dependency against C++ standard library.
-
-The decision to use C++ has been helping us to be more productive but it's not
-best because we cannot use C++ standard library and a few of C++ features which
-depend on this. This also prevents us from using other C++ library which rely 
-on the library. (e.g. abseil)
+In the past, we allowed the use of C++ code in the gRPC Core library 
+(link to the proposal), but we stayed conservative and avoided introducing
+a dependency on C++ standard library. Being able to use C++ has lead to 
+increased productivity, but there are still significant limitations, 
+because many useful C++ features depend on the standard C++ library.
+This also prevents us from using other C++ library which rely on the library.
+(e.g. abseil)
 
 This gRFC proposes allowing C++ standard library to be used within the gRPC 
 Core library. It may free us from reinventing wheels which already exists
@@ -32,12 +31,14 @@ in the standard library and help us become more productive.
 
 ## Proposal
 
-Allow C++11 standard library usage in gRPC Core. The previous C++ usage rule
+Allow C++11 standard library usage in gRPC Core. The previous C++ usage rules
 will be valid except the restriction on C++ features and header-only library.
 
-- All C++11 features are allowed to use. Followings were not possible to use
-  but it becomes available with this.
+- All C++11 features are allowed to use. Following C++11 features will become
+  available with this proposal.
   - `new` and `delete`
+    - With this, all built-in std allocators can be ready to use. No need to
+      specify custom new/delete functors when special behavior is not needed.
     - Even though `new` and `delete` now become possible to use, it doesn't
       necessarily mean that all code should use.
       For the place where `gpr_malloc` and `gpr_free` should be used
@@ -74,7 +75,7 @@ Here is what matters to C++.
 
   - GLIBCXX <= 3.4.9 (GCC 4.2.0)
 
-Fortunately, most of C++ standrad library availble on this restriction.
+Fortunately, most of C++ standrad library available on this restriction.
 Following is a partial list of missing features because of `manylinux1`.
   - std::chrono.
   - std::numeric_limits for long long and some methods.

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -5,7 +5,7 @@ Allow C++ standard library in gRPC Core Library
 * Status: Draft
 * Implemented in: n/a
 * Last updated: August 19, 2019
-* Discussion at: <TBD>
+* Discussion at: https://groups.google.com/forum/#!topic/grpc-io/umQyyXmNr2w
 
 ## Abstract
 
@@ -62,13 +62,13 @@ have full C++11 standard library.
 Using C++ standard library gives us several advantages:
 - gRPC Core can use all useful and essential classes in C++ standard library.
   This allows us not to reinvent everything which are already available.
-- gRPC Core can use other libraries which requires C++ standard library.
+- gRPC Core can use other libraries which require C++ standard library.
   Previously linking to abseil or protobuf was impossible because it requires C++
   standard library. With this, we can consider it.
 
-All previous restrictions not to link the library are arbitrary and it can
-change anytime because it's not part of standard or specification but
-implementation details. Having gRPC built by `gcc` and `libstdc++` doesn't
+All previous restrictions not to link the C++ standard library are arbitrary
+and it can change anytime because it's not part of standard or specification
+but implementation details. Having gRPC built by `gcc` and `libstdc++` doesn't
 guarantee that it can achieve the same goal with `clang` and `libc++`.
 
 ## Implementation

--- a/L59-core-allow-cppstdlib.md
+++ b/L59-core-allow-cppstdlib.md
@@ -108,8 +108,10 @@ doesn't guarantee that it can achieve the same goal with `clang` and `libc++`.
 
 1. Change the build configuration for all wrapped language to add the dependency
    to the C++ standard library.
+   [#19918](https://github.com/grpc/grpc/pull/19918)
 2. Make changes to use the C++ standard library to prove it's working.
    The change should be small enough so that we can easily roll it back.
+   [#20059](https://github.com/grpc/grpc/pull/20059)
    - Replace `grpc_core::map` with `std::map`
    - Replace `GRPC_ABSTRACT` with `= 0`
 3. Add new build tests to make sure that the version of library gRPC uses is
@@ -120,7 +122,9 @@ doesn't guarantee that it can achieve the same goal with `clang` and `libc++`.
 
 1. New dependency against the C++ standard library is added with some code
    depending on it. This must be easy to roll back in case of errors.
-   -> Target gRPC 1.25 (scheduled on October 22, 2019)
-2. Once this version looks fine like there is no breaking change,
+   - gRPC master branch gets this change with
+      [#19918](https://github.com/grpc/grpc/pull/19918) (on September 3, 2019)
+   - Released with gRPC 1.24 (scheduled on September 24, 2019)
+2. Once gRPC 1.24 release looks fine like there is no breaking change,
    the gRPC Core will be able to use the C++ standard library.
-   -> From gRPC 1.26-dev
+   - From gRPC 1.25-dev (after September 24, 2019)


### PR DESCRIPTION
This is a proposal to allow C++ standard library in gRPC Core Library and gRPC Core will be full C++11  compliant with this.

[Discussion Thread](https://groups.google.com/forum/#!topic/grpc-io/umQyyXmNr2w)