### PR TITLE
update retry proposal

### DIFF
--- a/A6-client-retries.md
+++ b/A6-client-retries.md
@@ -312,7 +312,7 @@ Similarly, transparent retries do not count toward the limit of configured RPC a
 
 Both client and server application logic will have access to data about retries via gRPC metadata. Upon seeing an RPC from the client, the server will know if it was a retry, and moreover, it will know the number of previously made attempts. Likewise, the client will receive the number of retry attempts made when receiving the results of an RPC.
 
-The header name for exposing the metadata will be `"grpc-previous-rpc-attempts"` to give clients and servers access to the attempt count. This value represents the number of preceding retry attempts. Thus, it will not be present on the first RPC, will be 1 for the second RPC, and so on. The value for this field will be an integer.
+The header name for exposing the metadata will be `"grpc-previous-rpc-attempts"` to give clients and servers access to the attempt count. This value represents the number of preceding retry attempts. On the first RPC, will be 0; on the second RPC, it will be 1, and so on. The value for this field will be an integer.
 
 #### Disabling Retries
 


### PR DESCRIPTION
Currently, the retry proposal specifies sending "grpc-previous-rpc-attempts"
metadata on each RPC beyond the first RPC.

However, this makes it hard to use: the absence of the metadata could either be
RPC attempt #0, or an RPC (of any attempt #) using a version of the gRPC library
before this logic is implemented. (or, the version of the client library that
was updated to use this field)

That is: we could never tell, for example, %QPS that are related to retries
because we don't know what our sample size is. By specifying first RPC must send
grpc-previous-rpc-attempts=0, we can do #rpcs-whose-attempts>0 / #rpcs-with-any-attempts.