### PR TITLE
Add env guard for header-control fault injection

### DIFF
--- a/A33-Fault-Injection.md
+++ b/A33-Fault-Injection.md
@@ -138,6 +138,8 @@ According to the [Envoy implementation](https://github.com/envoyproxy/envoy/blob
 
 `GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION` as an environment variable will be used to guard this feature for the initial release. Once it is set, gRPC will start to interpret xDS HTTP filters ([A39: xDS HTTP Filters](https://github.com/grpc/proposal/pull/219)) and enforce fault injection if configured. This environment variable protection will be removed once the new feature has proven to be stable.
 
+`GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION_HEADER_CONTROL` as an environment variable will be used to guard the header control feature of client-side fault injection. If this feature is not enabled, gRPC should reject filter configs containing `HeaderDelay` and `HeaderAbort`. This environment variable protection will be removed once the header control feature is proven to be stable in interop tests between gRPC implementations.
+
 
 ## Alternatives
 

--- a/A33-Fault-Injection.md
+++ b/A33-Fault-Injection.md
@@ -138,7 +138,7 @@ According to the [Envoy implementation](https://github.com/envoyproxy/envoy/blob
 
 `GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION` as an environment variable will be used to guard this feature for the initial release. Once it is set, gRPC will start to interpret xDS HTTP filters ([A39: xDS HTTP Filters](https://github.com/grpc/proposal/pull/219)) and enforce fault injection if configured. This environment variable protection will be removed once the new feature has proven to be stable.
 
-`GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION_HEADER_CONTROL` as an environment variable will be used to guard the header control feature of client-side fault injection. If this feature is not enabled, gRPC should reject filter configs containing `HeaderDelay` and `HeaderAbort`. This environment variable protection will be removed once the header control feature is proven to be stable in interop tests between gRPC implementations.
+`GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION_HEADER_CONTROL` as an environment variable will be used to guard the header control feature of client-side fault injection. If this feature is not enabled, gRPC should simply ignore the presence of `HeaderDelay` and `HeaderAbort`. This environment variable protection will be removed once the header control feature is proven to be stable in interop tests between gRPC implementations.
 
 
 ## Alternatives


### PR DESCRIPTION
`GRPC_XDS_EXPERIMENTAL_FAULT_INJECTION_HEADER_CONTROL` will be used to guard the fault injection header config overriding feature. As discussed offline with @dfawley, we currently don't have an easy way to test this feature in our interop tests, and we don't want to risk producing an untested feature that might stuck with old client forever. This env should be lifted once we have proper interop tests for it.

@dapengzhang0 @dfawley CC @srini100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/proposal/228)
<!-- Reviewable:end -->
