### PR TITLE
A36: If multiple %s in template, replace them all

### DIFF
--- a/A36-xds-for-servers.md
+++ b/A36-xds-for-servers.md
@@ -131,8 +131,9 @@ The `GRPC_XDS_BOOTSTRAP` file will be enhanced to have a new field:
 ```
 {
   // A template for the name of the Listener resource to subscribe to for a gRPC
-  // server. If the token `%s` is present in the string, it will be replaced
-  // with the server's listening "IP:port" (e.g., "0.0.0.0:8080", "[::]:8080").
+  // server. If the token `%s` is present in the string, all instances of the
+  // token will be replaced with the server's listening "IP:port" (e.g.,
+  // "0.0.0.0:8080", "[::]:8080").
   "server_listener_resource_name_template": "example/resource/%s",
   // ...
 }


### PR DESCRIPTION
The previous behavior was undefined. We don't know why someone would
need the host:port included multiple times, but there's not much point
in stopping them.

CC @easwars, @yashykt, @sanjaypujare, @dfawley 