### PR TITLE
L74: Fix missed updates to factory methods

### DIFF
--- a/L74-java-channel-creds.md
+++ b/L74-java-channel-creds.md
@@ -438,7 +438,7 @@ ServerCredentials tlsCreds = TlsServerCredentials.create(
     new File("cert.pem"), new File("cert.key"));
 server = Grpc.newServerBuilderForPort(443, tlsCreds)
     .build().start();
-server = Grpc.newServerBuilderForPort(8080, InsecureChannelCredentials.create())
+server = Grpc.newServerBuilderForPort(8080, InsecureServerCredentials.create())
     .build().start();
 ```
 
@@ -500,7 +500,7 @@ public final class TlsServerCredentials extends ServerCredentials {
         throws IOException {...}
 
     // Throws if no certificate was provided
-    public ChannelCredentials build() {...}
+    public ServerCredentials build() {...}
   }
 }
 ```

--- a/L74-java-channel-creds.md
+++ b/L74-java-channel-creds.md
@@ -67,11 +67,11 @@ channel = ManagedChannelBuilder.forTarget("example.com").usePlaintext()
 channel = ManagedChannelBuilder.forAddress("example.com", 443)
     .build();
 // the user would now:
-channel = Grpc.newChannelBuilder("example.com", new TlsChannelCredentials())
+channel = Grpc.newChannelBuilder("example.com", TlsChannelCredentials.create())
     .build();
-channel = Grpc.newChannelBuilder("example.com", new InsecureChannelCredentials())
+channel = Grpc.newChannelBuilder("example.com", InsecureChannelCredentials.create())
     .build();
-channel = Grpc.newChannelBuilderForAddress("example.com", 443, new TlsChannelCredentials())
+channel = Grpc.newChannelBuilderForAddress("example.com", 443, TlsChannelCredentials.create())
     .build();
 ```
 
@@ -434,11 +434,11 @@ server = ServerBuilder.forPort(443)
 server = ServerBuilder.forPort(8080)
     .build().start();
 // the user would now:
-ServerCredentials tlsCreds = new TlsServerCredentials(
+ServerCredentials tlsCreds = TlsServerCredentials.create(
     new File("cert.pem"), new File("cert.key"));
 server = Grpc.newServerBuilderForPort(443, tlsCreds)
     .build().start();
-server = Grpc.newServerBuilderForPort(8080, new InsecureChannelCredentials())
+server = Grpc.newServerBuilderForPort(8080, InsecureChannelCredentials.create())
     .build().start();
 ```
 


### PR DESCRIPTION
All the class definitions were swapped from exposing constructors to
factory methods, but the examples weren't.