### PR TITLE
Specify the flow control behavior in BinderChannel protocol

### DIFF
--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -35,7 +35,8 @@ For general transport lifecycle, using one of 1000 reserved transaction codes.
 *   Acknowledge bytes.
     *   Transaction code: BinderTransport.ACKNOWLEDGE_BYTES (3)
     *   From either transport to its peer's binder. Reports reception of
-        transaction data for flow control.
+        transaction data for flow control. The "num bytes" field should contain
+        the sum of "data size" of the parcels received until now.
 *   Ping
     *   Transaction code: BinderTransport.PING (4)
     *   Currently only sent from ClientTransport to server binder.
@@ -204,7 +205,7 @@ side.
 
 ## Flow Control
 
-Due to the limited binder buffer size of 1MB, BinderTransport now supports flow control, aiming to keep use of the process transaction buffer to at most 128k. Each transaction we send adds to an internal count of unacknowledged outbound data. If that exceeds 128k, we’ll stop sending transactions until we receive an acknowledgement message from the transport peer. Each transport sends an acknowledgement for each 16k received, which should avoid blocking the transport most of the time.
+Due to the limited binder buffer size of 1MB, BinderTransport now supports flow control, aiming to keep use of the process transaction buffer to at most 128k. Each transaction we send adds to an internal count of unacknowledged outbound data (here the count refers to the "data size" of the parcels). If that exceeds 128k, we’ll stop sending transactions until we receive an acknowledgement message from the transport peer. Each transport sends an acknowledgement for each 16k received, which should avoid blocking the transport most of the time.
 
 For message larger than the flow control window size, the transport can choose to split it into multiple chunks using the FLAG_MESSAGE_DATA_IS_PARTIAL flag.
 

--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -36,7 +36,7 @@ For general transport lifecycle, using one of 1000 reserved transaction codes.
     *   Transaction code: BinderTransport.ACKNOWLEDGE_BYTES (3)
     *   From either transport to its peer's binder. Reports reception of
         transaction data for flow control. The "num bytes" field should contain
-        the sum of "data size" of the parcels received until now.
+        the sum of "[data size]" of the parcels received until now.
 *   Ping
     *   Transaction code: BinderTransport.PING (4)
     *   Currently only sent from ClientTransport to server binder.
@@ -226,4 +226,4 @@ most of the time.
 [Binder]: https://developer.android.com/reference/android/os/Binder
 [Parcel]: https://developer.android.com/reference/android/os/Parcel
 [onBind]: https://developer.android.com/reference/android/app/Service#onBind\(android.content.Intent\)
-
+[data size]: https://developer.android.com/reference/android/os/Parcel#dataSize()

--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -214,14 +214,14 @@ all but the last transaction having FLAG_MESSAGE_DATA_IS_PARTIAL set.
 
 ## Flow Control
 
-Due to the limited binder buffer size of 1MB, BinderTransport supports
-transport-level flow control, aiming to keep use of the process transaction
-buffer to at most 128KB. Each transaction we send adds to an internal count of
-unacknowledged outbound data (here the count refers to the "data size" of the
-parcels). If that exceeds 128KB, we’ll stop sending transactions until we receive
-an acknowledgement message from the transport peer. Each transport sends an
-acknowledgement for each 16KB received, which should avoid blocking the transport
-most of the time.
+Due to Android's limited per-process transaction buffer of 1MB, BinderTransport
+supports transport-level flow control, aiming to keep use of the process
+transaction buffer to at most 128KB. Each transaction we send adds to an
+internal count of unacknowledged outbound data (here the count refers to the
+"data size" of the parcels). If that exceeds 128KB, we’ll stop sending
+transactions until we receive an acknowledgement message from the transport
+peer. Each transport sends an acknowledgement for each 16KB received, which
+should avoid blocking the transport most of the time.
 
 [Binder]: https://developer.android.com/reference/android/os/Binder
 [Parcel]: https://developer.android.com/reference/android/os/Parcel

--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -204,9 +204,9 @@ side.
 
 ## Flow Control
 
-BinderTransport now supports flow control, aiming to keep use of the process transaction buffer to at most 128k. Each transaction we send adds to an internal count of unacknowledged outbound data. If that exceeds 128k, we’ll stop sending transactions until we receive an acknowledgement message from the transport peer. Each transport sends an acknowledgement for each 16k received, which should avoid blocking the transport most of the time.
+Due to the limited binder buffer size of 1MB, BinderTransport now supports flow control, aiming to keep use of the process transaction buffer to at most 128k. Each transaction we send adds to an internal count of unacknowledged outbound data. If that exceeds 128k, we’ll stop sending transactions until we receive an acknowledgement message from the transport peer. Each transport sends an acknowledgement for each 16k received, which should avoid blocking the transport most of the time.
 
-For message larger than the flow control window size, the transport can choose to split it into multiple chunks using the FLAG_MESSAGE_DATA_IS_PARTIAL option.
+For message larger than the flow control window size, the transport can choose to split it into multiple chunks using the FLAG_MESSAGE_DATA_IS_PARTIAL flag.
 
 [Binder]: https://developer.android.com/reference/android/os/Binder
 [Parcel]: https://developer.android.com/reference/android/os/Parcel

--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -208,7 +208,7 @@ side.
 
 ## Large Messages
 
-We limit the amount of message data sent in a single transaction to 16k.
+We limit the amount of message data sent in a single transaction to 16KB.
 Messages larger than that will be sent in multiple sequential transactions, with
 all but the last transaction having FLAG_MESSAGE_DATA_IS_PARTIAL set.
 
@@ -216,11 +216,11 @@ all but the last transaction having FLAG_MESSAGE_DATA_IS_PARTIAL set.
 
 Due to the limited binder buffer size of 1MB, BinderTransport supports
 transport-level flow control, aiming to keep use of the process transaction
-buffer to at most 128k. Each transaction we send adds to an internal count of
+buffer to at most 128KB. Each transaction we send adds to an internal count of
 unacknowledged outbound data (here the count refers to the "data size" of the
-parcels). If that exceeds 128k, we’ll stop sending transactions until we receive
+parcels). If that exceeds 128KB, we’ll stop sending transactions until we receive
 an acknowledgement message from the transport peer. Each transport sends an
-acknowledgement for each 16k received, which should avoid blocking the transport
+acknowledgement for each 16KB received, which should avoid blocking the transport
 most of the time.
 
 [Binder]: https://developer.android.com/reference/android/os/Binder

--- a/L73-java-binderchannel/wireformat.md
+++ b/L73-java-binderchannel/wireformat.md
@@ -148,7 +148,10 @@ rpc transaction = flags, sequence no, rpc data;
     included.
 *   FLAG_MESSAGE_DATA_IS_PARCELABLE (0x40) - Indicates the message is a parcelable
     object.
-*   FLAG_MESSAGE_DATA_IS_PARTIAL (0x80) - Indicates the message is partial and the receiver should continue reading. When a message doesn't fit into a single transaction, the message will be sent in multiple transactions with this bit set on all but the final transaction of the message.
+*   FLAG_MESSAGE_DATA_IS_PARTIAL (0x80) - Indicates the message is partial and
+    the receiver should continue reading. When a message doesn't fit into a
+    single transaction, the message will be sent in multiple transactions with
+    this bit set on all but the final transaction of the message.
 *   status - If a status is included in the data, the status code will be
     present in the top 16 bits of the flags value.
 
@@ -205,11 +208,20 @@ side.
 
 ## Large Messages
 
-We limit the amount of message data sent in a single transaction to 16k. Messages larger than that will be sent in multiple sequential transactions, with all but the last transaction having FLAG_MESSAGE_DATA_IS_PARTIAL set.
+We limit the amount of message data sent in a single transaction to 16k.
+Messages larger than that will be sent in multiple sequential transactions, with
+all but the last transaction having FLAG_MESSAGE_DATA_IS_PARTIAL set.
 
 ## Flow Control
 
-Due to the limited binder buffer size of 1MB, BinderTransport supports transport-level flow control, aiming to keep use of the process transaction buffer to at most 128k. Each transaction we send adds to an internal count of unacknowledged outbound data (here the count refers to the "data size" of the parcels). If that exceeds 128k, we’ll stop sending transactions until we receive an acknowledgement message from the transport peer. Each transport sends an acknowledgement for each 16k received, which should avoid blocking the transport most of the time.
+Due to the limited binder buffer size of 1MB, BinderTransport supports
+transport-level flow control, aiming to keep use of the process transaction
+buffer to at most 128k. Each transaction we send adds to an internal count of
+unacknowledged outbound data (here the count refers to the "data size" of the
+parcels). If that exceeds 128k, we’ll stop sending transactions until we receive
+an acknowledgement message from the transport peer. Each transport sends an
+acknowledgement for each 16k received, which should avoid blocking the transport
+most of the time.
 
 [Binder]: https://developer.android.com/reference/android/os/Binder
 [Parcel]: https://developer.android.com/reference/android/os/Parcel


### PR DESCRIPTION
The flow control mechanism is specified in the internal document but was not included in this proposal. Also, both documents didn't contain the description of the flag `FLAG_MESSAGE_DATA_IS_PARTIAL`, which is crucial when breaking larger message into smaller chunks for flow control purposes.

This PR copies the description of flow control mechanism in the internal document to the proposal, and explicitly introduce `FLAG_MESSAGE_DATA_IS_PARTIAL` and its usage. Additionally, the `num bytes` field in `ACKNOWLEDGE_BYTES` requests should be of type `long` (64 bits) instead of `int` (32 bits) judging from the implenmentation.