### PR TITLE
A41 update: Call out precise HeaderMatcher.invert_match semantics

### DIFF
--- a/A41-xds-rbac.md
+++ b/A41-xds-rbac.md
@@ -146,6 +146,12 @@ status code INTERNAL, or RST_STREAM with HTTP/2 error code PROTOCOL_ERROR. These
 restrictions and behavior produce a singular, unambiguous authority for every
 request to be used by RBAC and the application itself.
 
+If a header is not present, `HeaderMatch` will not match _except_ for
+`present_match` when `present_match == invert_match`. This is because
+`HeaderMatcher.invert_match` inverts the comparison operation so
+something like `exact_match` changes from an `==` comparison to a `!=`
+comparison, and both fail to match if the header is not present.
+
 In RBAC `metadata` refers to the Envoy metadata which has no relation to gRPC
 metadata. Envoy metadata is generic state shared between filters, which has no
 gRPC equivalent. RBAC implementations in gRPC will treat Envoy metadata as an


### PR DESCRIPTION
The proper behavior is subtle and easy to assume incorrectly. This
caused a bug in Go (https://github.com/grpc/grpc-go/issues/4896) and
would be easy for other implementations to assume incorrectly.

As determined by Envoy's behavior:
https://github.com/envoyproxy/envoy/blob/7d3e444d757696c15a4020b1d2d8ba5cb7f12501/source/common/http/header_utility.cc#L140-L146

CC @YifeiZhuang, @zasweq, @ashithasantosh, @yashykt 

----

This got brought up recently in https://github.com/grpc/grpc/pull/27754, where it was pointed out MetadataMatcher.invert behaves differently. MetadataMatcher.invert was added after this gRFC, so I'm not yet calling out its behavior. But I did see that Go's behavior didn't match the necessary behavior, so let's at least take a baby step and define the behavior of HeaderMatcher.