### PR TITLE
A50 update: Fix failure percentage minimum hosts check

### DIFF
--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -192,7 +192,7 @@ The subchannel wrapper will track the latest state update from the underlying su
 
 ### Failure Percentage Algorithm
 
- 1. If the number of addresses is less than `failure_percentage_ejection.minimum_hosts`, stop.
+ 1. If the number of addresses with request volume of at least `failure_percentage_ejection.request_volume` is less than `failure_percentage_ejection.minimum_hosts`, stop.
  2. For each address:
     1. If the percentage of ejected addresses is greater than `max_ejection_percent`, stop.
     2. If the address's total request volume is less than `failure_percentage_ejection.request_volume`, continue to the next address.


### PR DESCRIPTION
The previous text here was an incorrect interpretation/transcription of the Envoy spec. [The relevant part of the Envoy spec](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier#failure-percentage) says

> Detection also will not be performed for a cluster if the number of hosts with the minimum required request volume in an interval is less than the [outlier_detection.failure_percentage_minimum_hosts](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-field-config-cluster-v3-outlierdetection-failure-percentage-minimum-hosts) value.