### PR TITLE
A30 update: remove info about ongoing xDS version changes

### DIFF
--- a/A30-xds-v3.md
+++ b/A30-xds-v3.md
@@ -5,7 +5,8 @@ A30: xDS v3 Support
 * Status: Final
 * Implemented in: C-core, Java, Go, Node
 * Last updated: 2022-10-11
-* Discussion at: https://groups.google.com/g/grpc-io/c/YRVqRMUQwhM
+* Discussion at: https://groups.google.com/g/grpc-io/c/YRVqRMUQwhM and
+  https://groups.google.com/g/grpc-io/c/pfwDmD7cpp0
 
 ## Abstract
 


### PR DESCRIPTION
The xDS ecosystem no longer plans to release a new version of the xDS API every year.  As a result, we no longer need a policy of supporting two versions of xDS at any given time, so I am removing that content from this gRFC.

gRPC plans to drop support for xDS v2 in the near future.