### PR TITLE
A59: gRPC Audit Logging

### DIFF
--- a/A58-audit-logging.md
+++ b/A58-audit-logging.md
@@ -1,0 +1,243 @@
+A58: gRPC Audit Logging
+----
+* Author(s): [Luwei Ge](https://github.com/rockspore)
+* Approver:
+* Status: Draft {Draft, In Review, Ready for Implementation, Implemented}
+* Implemented in:
+* Last updated: 2023-03-09
+* Discussion at: 
+
+## Abstract
+
+Support audit logging based on authorization events in gRPC servers in both
+xDS-enabled and gRPC authorization policy based use cases.
+
+## Background
+
+gRPC's authorization support is based on the [RBAC policy][]. In
+xDS-enabled cases, users can configure authorization policies in the control
+plane which applies [RBAC HTTP filters][RBAC filter] to the gRPC servers. When
+xDS is not an option, users can use the [gRPC authorization policy][A43] to
+get similar authorization enforment.
+
+This proposal describes the audit logging APIs that allow users to audit
+specific authorization events in their gRPC servers with the necessary context.
+We aim to offer consistent APIs to support both aforementioned use cases.
+
+[RBAC filter]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/filters/http/rbac/v3/rbac.proto
+[RBAC policy]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/config/rbac/v3/rbac.proto
+[HttpConnectionManager proto]: https://github.com/envoyproxy/envoy/blob/main/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+
+### Related Proposals: 
+* [gRFC A41: xDS RBAC Support][A41]
+* [gRFC A43: gRPC Authorization API][A43]
+
+[A41]: A41-xds-rbac.md
+[A43]: A43-grpc-authorization-api.md
+
+## Proposal
+
+### Audit Context
+
+The table below lists the metadata we will include in the audit context,
+which will be made available to audit loggers during an audit event.
+
+It is worth noting that audit happens right after the authorization
+decision is made, so the status only reflects that but not the eventual
+one from the server. 
+
+|Fields             |Additional Information                                                             |Example                |
+|-------------------|-----------------------------------------------------------------------------------|-----------------------|
+|RPC Method         |Method the RPC hit.                                                                |"/pkg.service/foo"     |
+|Principal          |Identity the RPC. Currently only available in certificate-based TLS authentication.|"spiffe://foo/user1"   |
+|Timestamp          |Time when the RPC happens.                                                         |1649376211             |
+|Denying Policy Name|Policy name that denied the RPC. Empty if RPC is allowed.                          |"policy_name"          |
+|Status             |gRPC status from the authorization enforcement, not the eventual RPC status.       |OK or PERMISSION_DENIED|
+
+### xDS API Changes
+
+xDS API changes are needed because gRPC authorization is entirely based on [xDS RBAC policy][RBAC policy]. Moreoever, audit logging is a common feature
+that other xDS clients (namely Envoy) should benefit from as well.
+
+We will add an audit condition enum in the [xDS RBAC policy][RBAC policy] as
+below:
+
+```
+package envoy.config.rbac.v3;
+
+message RBAC {
+  ...
+
+  // Deny and allow here refer to RBAC decisions, not actions.
+  enum AuditCondition {
+    // Never audit.
+    NONE = 0;
+
+    // Audit when RBAC denies the request.
+    ON_DENY = 1;
+
+    // Audit when RBAC allows the request.
+    ON_ALLOW = 2;
+
+    // Audit whether RBAC allows or denies the request.
+    ON_DENY_AND_ALLOW = 3;
+  }
+
+  // Condition for the audit logging to be happen, specific to HTTP filters.
+  // If condition is met, all the audit loggers configured in the HCM will be invoked.
+  //
+  AuditCondition audit_condition = 3;
+}
+```
+
+Note that `DENY` and `ALLOW` in the enum refer to the RBAC decisions, not
+RBAC actions.
+
+For the audit logger configuration, we will follow the existing `access_log`
+field in the [HTTP Connection Manager][HttpConnectionManager proto] by adding
+a typed extension category `audit_log`:
+
+```
+package envoy.extensions.filters.network.http_connection_manager.v3;
+
+message HttpConnectionManager {
+  ...
+  
+  // Configuration for the audit log.
+  // The audit_loggers instantiated from this will be used in all RBAC filters.
+  //
+  // [#extension-category: envoy.audit_loggers]
+  repeated xds.core.v3.TypedExtensionConfig audit_log = 53;
+}
+```
+
+The list of configured audit loggers will all be invoked by an RBAC filter when
+the audit condition is met. This is analogus to the semantics that all access
+loggers will be run after the response is sent.
+
+### gRPC Authorzation Policy Changes
+
+The gRPC authorization policy consists of `deny_rules` and `allow_rules`, which
+are mapped to two RBACs. Overall it's a subset of the RBAC as stated in [A43: gRPC authorization API][A43].
+We will keep this philosophy by adding just one `audit_condition` in the policy
+instead of having separate conditions for those two set of rules. Likewise, only
+one audit logger can be specified, the configuration of which is the json
+representation of the typed config used in xDS.
+
+Following are changes to the JSON schema of gRPC Authorization Policy introduced
+in [A43: gRPC authorization API][A43]:
+
+```json
+{
+  "title": "AuthorizationPolicy",
+  "definitions": {
+    ...
+    "audit_log": {
+      "description": "Configuration for the audit log.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the audit_log configuration."
+            "It is mainly used for human purposes.",
+          "type": "string",
+        },
+        "typed_config": {
+          "description": "The typed config for the audit_log."
+            "This needs to be a json object mapped from google.protobuf.Any"
+            "proto message.",
+          "type": "object",
+        }
+      },
+    }
+  },
+  "properties": {
+    ...
+    "audit_condition": {
+      "description": "Condition for the audit logging to be happen."
+        "Same as NONE if ommited.",
+      "type": "string",
+      "enum": ["NONE", "ON_DENY", "ON_ALLOW", "ON_DENY_AND_ALLOW"]
+    },
+    "audit_log": {
+      "$ref": "#/definitions/audit_log"
+    }
+  },
+  "required": ["name", "allow_rules"]
+}
+```
+
+For readers that are more familiar with proto messages, the change translates
+to:
+
+```
+message AuthorizationPolicy {
+  …
+
+  enum AuditCondition {
+    NONE = 0;
+    ON_DENY = 1;
+    ON_ALLOW = 2;
+    ALWAYS = 3;
+  }
+
+  AuditCondition audit_condition = 1;
+
+  // See https://github.com/cncf/xds/blob/main/xds/core/v3/extension.proto.
+  xds.core.v3.TypedExtensionConfig audit_log = 2;
+}
+```
+
+Note that the definition above is only for illustration purposes and does not
+actually exist anywhere as a `.proto` file. Nor does gRPC process the policy
+as protobuf by any means.
+
+### Language Specific APIs
+
+_This section is to be done once the language-agnostic APIs are more finalized._
+
+_What is certain for now is we need to support third-party audit logger
+implementations registered by users._
+
+## Rationale
+
+So far, we have considered alternatives in a number of othorgonal aspects.
+
+### Utilizing the Access Log
+
+The [information](https://github.com/envoyproxy/envoy/blob/main/api/envoy/data/accesslog/v3/accesslog.proto)
+present in the existing access log is sufficient for audit purposes. However,
+access log does not happen till the response is sent and therefore does not
+fit the audit logging use case well. For example, for long-living RPCs, users
+would want to audit the event right after the authorization is enfoced but
+access log won't necessarily happen till hours later.
+
+### Audit Condition in the HTTP Connection Manager
+
+As an HTTP filter chain can contain multiple RBAC filters in general. The typical
+behavior that users will expect if they want to audit on allow is audit should
+only happen once after the evaluation of the last RBAC filter. From this
+perspective, the audit condition could be considered as something on top of all
+RBAC filters and thus configured in the [HTTP Connection Manager][HttpConnectionManager proto].
+
+However, given that xDS users normally do not craft RBACs on their own but instead
+rely on the control plane APIs, such as Istio Authorization Policy, it is
+reasonable to let the control plane handle the translation properly.
+Meanwhile, configuring audit condition in individual RBACs offers the flexibility
+when users really want to audit events related to a particular RBAC.
+
+### Audit Log Configured In gRPC Bootstrap
+
+Instead of having the audit log configuration delivered from the control plane,
+we could follow the xDS TLS certificate provider in [A29: xDS-Based Security for gRPC Clients and Servers](A29-xds-tls-security.md)
+where the configuration is placed in the gRPC bootstrap file.
+
+The advantage of that apporoach is the control plane would not need to know
+the platform-specific configuration options in the data plane, if any.
+But we concluded that in audit logging, the logger configuration should
+generally be uniform across the data plane and thus centralizing the configuration
+makes more sense. Moreover, the existing access log follows such a pattern
+in xDS, albeit not currently supported by gRPC.
+
+## Implementation
+
+The implementation order will be C++, Go, Java and then wrapped languages.

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -65,7 +65,7 @@ xDS clients (namely Envoy) should benefit from as well.
 We will add an audit condition enum (see [PR](https://github.com/envoyproxy/envoy/pull/26001))
 in the [xDS RBAC policy][RBAC policy] as below:
 
-```
+```proto
 package envoy.config.rbac.v3;
 
 message RBAC {

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -4,7 +4,7 @@ A59: gRPC Audit Logging
 * Approver: [Eric Anderson](https://github.com/ejona86)
 * Status: In Review {Draft, In Review, Ready for Implementation, Implemented}
 * Implemented in:
-* Last updated: 2023-03-09
+* Last updated: 2023-03-23
 * Discussion at: https://groups.google.com/g/grpc-io/c/LbnuqGqEwuM
 
 ## Abstract
@@ -120,6 +120,9 @@ allowing multiple audit loggers is useful when users plan to roll out a new
 logger. By also keeping the existing logger along for a period they will be able
 to prevent interruption.
 
+The RBAC filter will be NACKed if the configured logger types are not supported
+by gRPC, unless the filter it made optional. This is consistent with [A39: xDS HTTP Filter Support](https://github.com/grpc/proposal/blob/master/A39-xds-http-filters.md).
+
 Some readers may immediately notice that since an HTTP filter chain can contain
 an arbitrary number of RBAC filters, more than one of them could meet its audit
 condition for the same RPC and multiple audit log entries occur. When this happens,
@@ -194,7 +197,7 @@ to:
 
 ```proto
 message AuthorizationPolicy {
-  …
+  ...
 
   message AuditLoggingOptions {
     enum AuditCondition {
@@ -221,6 +224,9 @@ message AuthorizationPolicy {
 Note that the definition above is only for illustration purposes and does not
 actually exist anywhere as a `.proto` file. Nor does gRPC process the policy
 as protobuf by any means.
+
+Similar to the xDS case, unsupported logger types or any other misconfiguration
+will cause the server to fail to start.
 
 The authorization policy is backed by two RBAC filters, a DENY followed by an
 ALLOW. The audit logger configurations will be duplicated in both generated

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -284,8 +284,8 @@ use cases.
 ### Built-in logger types
 
 We plan to implement the stdout logger as a built-in logger type. The type is
-named `stdout_logger`. This logger will not support any configuration and it
-outputs log entries to stdout in JSON format.
+named `stdout_logger`. No configuration fields are currently defined for this
+logger and it outputs log entries to stdout in JSON format.
 
 Here is the example JSON configuration in the xDS case (see [PR](https://github.com/envoyproxy/envoy/pull/26453)).
 
@@ -328,9 +328,9 @@ will expose for users to implement their own types of audit loggers. Below are
 two important features that apply to all the languages.
 
 As is also documented in all the languages below, the logging function is
-executed by gRPC syncrhonously during the authorization process. Therefore,
+executed by gRPC synchronously during the authorization process. Therefore,
 its implementation should not block the RPC. When needed, it should invoke any
-long running operations asyncrhonously so that the function itself returns
+long running operations asynchronously so that the function itself returns
 promptly. For this reason, no error or status code will be returned from it.
 
 The logger factory (aka builder/provider) needs to implement a config parsing
@@ -577,14 +577,14 @@ for the users.
 In the xDS cases, however, the audit condition could be considered as something
 on top of all RBAC filters and thus configured in the [HTTP Connection Manager][HttpConnectionManager proto].
 We decided not to take this approach because the component managing the filter
-chain would have to be aware of the last RBAC filte and inform it if performing
+chain would have to be aware of the last RBAC filter and inform it if performing
 the audit logging. In other words, this would require more engineering effort
 which does not make too much sense for such a particular case as audit logging.
 
 In practice, xDS users normally do not craft RBACs on their own but instead
 rely on the control plane APIs, such as Istio's Authorization Policy, to apply
 RBAC filters to the workloads. We hope that when these control plane APIs
-start to support audit logging, they will only have a single RBAC policy o
+start to support audit logging, they will only have a single RBAC policy or
 will handle the logging behavior as what we do in the gRPC authorization policy
 case.
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -329,9 +329,10 @@ two important features that apply to all the languages.
 
 As is also documented in all the languages below, the logging function is
 executed by gRPC synchronously during the authorization process. Therefore,
-its implementation should not block the RPC. When needed, it should invoke any
-long running operations asynchronously so that the function itself returns
-promptly. For this reason, no error or status code will be returned from it.
+its implementation **must** not block the RPC. If a logger implementation needs
+to trigger any long-running work, it **must** do so asynchronously so that the
+function itself returns promptly. For this reason, no error or status code will
+be returned from it.
 
 The logger factory (aka builder/provider) needs to implement a config parsing
 function for parsing and validation logger configs, and a build function to

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -456,7 +456,7 @@ type AuditLoggerConfig interface {
 // denied or allowed.
 type AuditLogger interface {
 	// Log logs the auditing event with the given information.
-  // This method will be executed synchronously by gRPC so implementers must keep in mind it should
+	// This method will be executed synchronously by gRPC so implementers must keep in mind it should
 	// not block the RPC. Specifically, time-consuming processes should be fired asynchronously such
 	// that this method can return immediately.
 	Log(context.Context, *AuditInfo) error

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -324,4 +324,5 @@ in xDS, albeit not currently supported by gRPC.
 
 ## Implementation
 
-The implementation order will be C++, Go, Java and then wrapped languages.
+Implementation will first be done for C++ and Go. Following that will be Java,
+and finally wrapped languages will be implemented.

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -319,6 +319,12 @@ Some users may want to have their own audit logging logic which built-in
 loggers do not fullfil. This section is specifically about public APIs we
 will expose for users to implement their own types of audit loggers.
 
+As is also documented in all the languages below, the logging function is
+executed by gRPC syncrhonously during the authorization process. Therefore,
+it's implementation should not block the RPC. When needed, it should invoke any
+long running operations asyncrhonously so that the function itself returns
+promptly. For this reason, no error or status code will be returned from it.
+
 #### C++ APIs
 
 A new header `audit_logging.h` declares all the classes users either need to

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -309,10 +309,11 @@ Here is the example in the authorization policy case.
 Following is an example log entry.
 
 ```json
-{"grpc_audit_log":{"timestamp":"2006-01-02T15:04:05Z07:00","rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
+{"grpc_audit_log":{"timestamp":"2006-01-02T15:04:05.999999999Z07:00","rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
 ```
 
-The timestamp in RFC3339 format represents the time when the logger is invoked.
+The timestamp in RFC3339 format with nanosecond-level precision represents the
+time when the logger is invoked.
 
 More types of loggers may be designed and implemented in the future. For users
 that just need to use the built-in loggers, everything will be configured in

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -50,7 +50,7 @@ one from the server.
 |-------------------|--------------------------------------------------------------------------------------|-----------------------|
 |RPC Method         |Method the RPC hit.                                                                   |"/pkg.service/foo"     |
 |Principal          |Identity of the RPC. Currently only available in certificate-based TLS authentication.|"spiffe://foo/user1"   |
-|Policy Name        |The authorization policy name (or the xDS RBAC filter name).                          |"example-policy"       |
+|Policy Name        |The authorization policy name (not applicable in xDS case).                           |"example-policy"       |
 |Matched Rule       |The matched rule or the matched policy name in [RBAC][RBAC policy]. Empty if no match.|"admin-access"         |
 |Authorized         |A boolean indicating whether the RPC is authorized or not.                            |true                   |
 
@@ -494,7 +494,7 @@ type LoggerBuilder interface {
 }
 ```
 
-#### Java APIs
+#### Java APIs (Subject to change)
 
 ```Java
 public class AuditContext {

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -89,7 +89,6 @@ message RBAC {
 
     // Condition for the audit logging to happen.
     // If this condition is met, all the audit loggers configured here will be invoked.
-    //
     AuditCondition audit_condition = 1 [(validate.rules).enum = {defined_only: true}];
 
     // Configurations for RBAC-based authorization audit loggers.
@@ -101,7 +100,6 @@ message RBAC {
 
   // Audit logging options that include the condition for audit logging to happen
   // and audit logger configurations.
-  //
   AuditLoggingOptions audit_logging_options = 3;
 }
 ```

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -309,7 +309,7 @@ Here is the example in the authorization policy case.
 Following is an example log entry.
 
 ```json
-{"grpc_audit_log":{"timestamp":"1649376211","rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
+{"grpc_audit_log":{"timestamp":1649376211,"rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
 ```
 
 The timestamp, as the number of seconds from the Unix Epoch, is generated from
@@ -329,7 +329,7 @@ two important features that apply to all the languages.
 
 As is also documented in all the languages below, the logging function is
 executed by gRPC syncrhonously during the authorization process. Therefore,
-it's implementation should not block the RPC. When needed, it should invoke any
+its implementation should not block the RPC. When needed, it should invoke any
 long running operations asyncrhonously so that the function itself returns
 promptly. For this reason, no error or status code will be returned from it.
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -71,30 +71,38 @@ package envoy.config.rbac.v3;
 message RBAC {
   ...
 
-  // Deny and allow here refer to RBAC decisions, not actions.
-  enum AuditCondition {
-    // Never audit.
-    NONE = 0;
+  message AuditLoggingOptions {
+    // Deny and allow here refer to RBAC decisions, not actions.
+    enum AuditCondition {
+      // Never audit.
+      NONE = 0;
 
-    // Audit when RBAC denies the request.
-    ON_DENY = 1;
+      // Audit when RBAC denies the request.
+      ON_DENY = 1;
 
-    // Audit when RBAC allows the request.
-    ON_ALLOW = 2;
+      // Audit when RBAC allows the request.
+      ON_ALLOW = 2;
 
-    // Audit whether RBAC allows or denies the request.
-    ON_DENY_AND_ALLOW = 3;
+      // Audit whether RBAC allows or denies the request.
+      ON_DENY_AND_ALLOW = 3;
+    }
+
+    // Condition for the audit logging to happen.
+    // If this condition is met, all the audit loggers configured here will be invoked.
+    //
+    AuditCondition audit_condition = 1 [(validate.rules).enum = {defined_only: true}];
+
+    // Configurations for RBAC-based authorization audit loggers.
+    //
+    // [#extension-category: envoy.rbac.audit_loggers]
+    repeated core.v3.TypedExtensionConfig audit_loggers = 2
+        [(validate.rules).repeated = {min_items: 1}];
   }
 
-  // Condition for the audit logging to be happen.
-  // If condition is met, all the audit loggers configured in the HCM will be invoked.
+  // Audit logging options that include the condition for audit logging to happen
+  // and audit logger configurations.
   //
-  AuditCondition audit_condition = 3;
-
-  // Configuration for the audit loggers.
-  //
-  // [#extension-category: envoy.rbac.audit_loggers]
-  repeated xds.core.v3.TypedExtensionConfig audit_log = 4;
+  AuditLoggingOptions audit_logging_options = 3;
 }
 ```
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -2,10 +2,10 @@ A59: gRPC Audit Logging
 ----
 * Author(s): [Luwei Ge](https://github.com/rockspore)
 * Approver: [Eric Anderson](https://github.com/ejona86)
-* Status: Draft {Draft, In Review, Ready for Implementation, Implemented}
+* Status: In Review {Draft, In Review, Ready for Implementation, Implemented}
 * Implemented in:
 * Last updated: 2023-03-09
-* Discussion at: 
+* Discussion at: https://groups.google.com/g/grpc-io/c/LbnuqGqEwuM
 
 ## Abstract
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -250,20 +250,25 @@ use cases.
 
 ### Built-in logger types
 
-We plan to implement the standard stream logger as a built-in logger type. The
-type is named `standard_stream_logger`. The logger by default logs in JSON format
-to stdout. Independently, it can be configured to log in text format and log to
-stderr. Following is the example configuration in JSON.
+We plan to implement the stdout logger as a built-in logger type. The type is
+named `stdout_logger`. This logger will not support any configuration and it
+outputs log entries to stdout in JSON format.
+
+Here is the example configuration in JSON.
 
 ```json
 {
   "name": "user-defined-logger-name",
   "typed_config": {
-    "@type": "standard_stream_logger",
-    "log_format": "json",
-    "stream": "stdout",
+    "@type": "stdout_logger",
   }
 }
+```
+
+Following is an example log entry.
+
+```json
+{"timestamp":"1649376211","rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}
 ```
 
 More types of loggers may be designed and implemented in the future. For users

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -43,7 +43,7 @@ The table below lists the metadata we will include in the audit context,
 which will be made available to audit loggers during an audit event.
 
 It is worth noting that audit happens right after the authorization
-decision is made, so the status only reflects that but not the eventual
+decision is made, so the status only reflects that, but not the eventual
 one from the server. 
 
 |Fields             |Additional Information                                                             |Example                |
@@ -91,9 +91,12 @@ message RBAC {
 ```
 
 Note that `DENY` and `ALLOW` in the enum refer to the RBAC decisions, not
-RBAC actions. For example, we consider it as `DENY` decision when a RBAC
-rejects the RPC whether there is no policy match from a RBAC with `ALLOW`
-action or there is a match from a RBAC with `DENY` policy. Likewise for `ALLOW`.
+RBAC actions. For example, we consider it to be a `DENY` decision when a RBAC
+rejects the RPC, regardless of whether it is because there is no policy match
+from a RBAC with the `ALLOW` action, or because there is a match for a RBAC
+with a `DENY` action. Likewise, it is an `ALLOW` decision when there are no
+matches to RBACs with a `DENY` action and at least one match to an RBAC with an
+`ALLOW` action.
 
 For the audit logger configuration, we will follow the existing `access_log`
 field in the [HTTP Connection Manager][HttpConnectionManager proto] by adding
@@ -117,7 +120,7 @@ The list of configured audit loggers will all be invoked by an RBAC filter when
 the audit condition is met. This is analogus to the semantics that all access
 loggers will be run after the response is sent.
 
-### gRPC Authorzation Policy Changes
+### gRPC Authorization Policy Changes
 
 The gRPC authorization policy consists of `deny_rules` and `allow_rules`, which
 are mapped to two RBACs. Overall it's a subset of the RBAC as stated in [A43: gRPC authorization API][A43].
@@ -216,7 +219,7 @@ when the RPC passes through both RBACs.
 If users want to audit on both cases, then the `DENY` RBAC needs `ON_DENY` and
 the `ALLOW` RBAC needs `ON_DENY_AND_ALLOW`.
 
-Following is the table summarzing the combinations.
+Following is the table summarizing the combinations.
 
 |Authorization Policy  |DENY RBAC          |ALLOW RBAC           |
 |----------------------|-------------------|---------------------|

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -241,7 +241,28 @@ implementations registered by users._
 
 ## Rationale
 
-So far, we have considered alternatives in a number of othorgonal aspects.
+Audit logging helps users answer the questions of "who did what, where and when?".
+It is valuable for users to detect anomalous traffic patterns or monitor accesses
+to certain services.
+
+Therefore, authentication and authorization information needs to be available
+in the audit context. Since gRPC authorization is based on the [RBAC policy][RBAC policy],
+we design the audit logging feature around it to provide consistent APIs across
+xDS and non-xDS use cases. The proposed xDS API changes should also benefit
+other xDS clients which are currently lacking this feature as well.
+
+In both xDS and non-xDS cases, we expect users to configure the audit condition
+and audit loggers in language-agnostic configs and have the capability to inject
+their own logger implementations via the APIs we expose. This allows users to
+plug in their own audit logic while not having to restart the servers when
+reconfiguring the loggers.
+
+For auditing purposes, users should not log every incoming RPCs. In other words,
+`ON_DENY_AND_ALLOW` should seldom be used. But this is added as an option to
+support special cases where logging everything is required.
+
+Regarding alternative design options, following are what we have considered in
+a number of othorgonal aspects.
 
 ### Utilizing the Access Log
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -49,10 +49,10 @@ one from the server.
 |Fields             |Additional Information                                                                |Example                |
 |-------------------|--------------------------------------------------------------------------------------|-----------------------|
 |RPC Method         |Method the RPC hit.                                                                   |"/pkg.service/foo"     |
-|Principal          |Identity the RPC. Currently only available in certificate-based TLS authentication.   |"spiffe://foo/user1"   |
+|Principal          |Identity of the RPC. Currently only available in certificate-based TLS authentication.|"spiffe://foo/user1"   |
 |Policy Name        |The authorization policy name (or the xDS RBAC filter name).                          |"example-policy"       |
 |Matched Rule       |The matched rule or the matched policy name in [RBAC][RBAC policy]. Empty if no match.|"admin-access"         |
-|Authorized         |Boolean indicating whether the RPC is authorized or not.                              |true                   |
+|Authorized         |A boolean indicating whether the RPC is authorized or not.                            |true                   |
 
 ### xDS API Changes
 
@@ -148,8 +148,7 @@ in [A43: gRPC authorization API][A43]:
       "type": "object",
       "properties": {
         "name": {
-          "description": "The name of the audit logger configuration."
-            "It is mainly used for human purposes.",
+          "description": "The name of the audit logger type.",
           "type": "string",
         },
         "typed_config": {
@@ -188,6 +187,8 @@ in [A43: gRPC authorization API][A43]:
 }
 ```
 
+Note that the `name` field in `audit_logger` is essentially the logger type.
+This is not to be confused with the `name` field in [TypedExtensionConfig](https://github.com/cncf/xds/blob/main/xds/core/v3/extension.proto).
 For readers that are more familiar with proto messages, the change translates
 to:
 
@@ -260,7 +261,7 @@ We plan to implement the stdout logger as a built-in logger type. The type is
 named `stdout_logger`. This logger will not support any configuration and it
 outputs log entries to stdout in JSON format.
 
-Here is the example configuration in JSON.
+Here is the example JSON configuration in the xDS case.
 
 ```json
 {
@@ -268,6 +269,14 @@ Here is the example configuration in JSON.
   "typed_config": {
     "@type": "stdout_logger",
   }
+}
+```
+
+Here is the example in the authorization policy case.
+
+```json
+{
+  "name": "stdout_logger"
 }
 ```
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -3,8 +3,8 @@ A59: gRPC Audit Logging
 * Author(s): [Luwei Ge](https://github.com/rockspore)
 * Approver: [Eric Anderson](https://github.com/ejona86)
 * Status: In Review {Draft, In Review, Ready for Implementation, Implemented}
-* Implemented in:
-* Last updated: 2023-05-12
+* Implemented in: C++ and Go
+* Last updated: 2023-10-02
 * Discussion at: https://groups.google.com/g/grpc-io/c/LbnuqGqEwuM
 
 ## Abstract

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -1,4 +1,4 @@
-A58: gRPC Audit Logging
+A59: gRPC Audit Logging
 ----
 * Author(s): [Luwei Ge](https://github.com/rockspore)
 * Approver:

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -309,11 +309,10 @@ Here is the example in the authorization policy case.
 Following is an example log entry.
 
 ```json
-{"grpc_audit_log":{"timestamp":1649376211,"rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
+{"grpc_audit_log":{"timestamp":"2006-01-02T15:04:05Z07:00","rpc_method":"/pkg.Service/Foo","principal":"spiffe://foo/user1","policy_name":"example_policy","matched_rule":"admin_access","authorized":true}}
 ```
 
-The timestamp, as the number of seconds from the Unix Epoch, is generated from
-the current time when the logger is invoked.
+The timestamp in RFC3339 format represents the time when the logger is invoked.
 
 More types of loggers may be designed and implemented in the future. For users
 that just need to use the built-in loggers, everything will be configured in

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -317,13 +317,21 @@ required.
 
 Some users may want to have their own audit logging logic which built-in
 loggers do not fullfil. This section is specifically about public APIs we
-will expose for users to implement their own types of audit loggers.
+will expose for users to implement their own types of audit loggers. Below are
+two important features that apply to all the languages.
 
 As is also documented in all the languages below, the logging function is
 executed by gRPC syncrhonously during the authorization process. Therefore,
 it's implementation should not block the RPC. When needed, it should invoke any
 long running operations asyncrhonously so that the function itself returns
 promptly. For this reason, no error or status code will be returned from it.
+
+The logger factory (aka builder/provider) needs to implement a config parsing
+function for parsing and validation logger configs, and a build function to
+create loggers based on the parsed logger config. The former is needed to
+validate runtime configurations and reject them if needed before anything is
+acuated. The latter will be guaranteed to receive a validated config and must
+always succeed in creating a logger instance.
 
 #### C++ APIs
 

--- a/A59-audit-logging.md
+++ b/A59-audit-logging.md
@@ -50,7 +50,6 @@ one from the server.
 |-------------------|-----------------------------------------------------------------------------------|-----------------------|
 |RPC Method         |Method the RPC hit.                                                                |"/pkg.service/foo"     |
 |Principal          |Identity the RPC. Currently only available in certificate-based TLS authentication.|"spiffe://foo/user1"   |
-|Timestamp          |Time when the server saw the RPC.                                                  |1649376211             |
 |Policy Name        |Name of the policy that invokes audit logging.                                     |"policy_name"          |
 |Authorized         |Boolean indicating whether the RPC is authorized or not.                           |true                   |
 
@@ -137,17 +136,17 @@ in [A43: gRPC authorization API][A43]:
   "title": "AuthorizationPolicy",
   "definitions": {
     ...
-    "audit_log": {
-      "description": "Configuration for the audit log.",
+    "audit_logger": {
+      "description": "Configuration for the audit logger.",
       "type": "object",
       "properties": {
         "name": {
-          "description": "The name of the audit_log configuration."
+          "description": "The name of the audit logger configuration."
             "It is mainly used for human purposes.",
           "type": "string",
         },
         "typed_config": {
-          "description": "The typed config for the audit_log."
+          "description": "The typed config for the audit logger."
             "This needs to be a json object mapped from google.protobuf.Struct"
             "proto message.",
           "type": "object",
@@ -163,8 +162,8 @@ in [A43: gRPC authorization API][A43]:
       "type": "string",
       "enum": ["NONE", "ON_DENY", "ON_ALLOW", "ON_DENY_AND_ALLOW"]
     },
-    "audit_log": {
-      "$ref": "#/definitions/audit_log"
+    "audit_logger": {
+      "$ref": "#/definitions/audit_logger"
     }
   },
   "required": ["name", "allow_rules"]
@@ -187,12 +186,12 @@ message AuthorizationPolicy {
 
   AuditCondition audit_condition = 1;
 
-  message AuditLog {
+  message AuditLogger {
     string name = 1;
     google.protobuf.Struct config = 2;  
   }
   
-  AuditLog audit_log = 2;
+  AuditLogger audit_logger = 2;
 }
 ```
 


### PR DESCRIPTION
Still lacking the language-specific API sections. But I'd like to open this up so that folks commenting on https://github.com/envoyproxy/envoy/pull/26001 can have more context.