### PR TITLE
P4 update: Remove dead link to ISSUE_TEMPLATE

### DIFF
--- a/P4-grpc-cve-process.md
+++ b/P4-grpc-cve-process.md
@@ -28,7 +28,7 @@ A CVE disclosure process allows people to responsibly disclose these issues, and
 
 The gRPC Community asks that all suspected vulnerabilities be privately and responsibly disclosed via the Private Disclosure process described below:
 
-To make a report, email the private grpc-security@googlegroups.com list with the security details and the [details expected for all gRPC bug reports](https://github.com/grpc/grpc/blob/master/.github/ISSUE_TEMPLATE.md).
+To make a report, email the private grpc-security@googlegroups.com list with the security details. The list is shared across languages, so the email should include the impacted language and platform information as appropriate.
 
 #### When should I report a vulnerability
 * You think you have discovered a potential security vulnerability in gRPC


### PR DESCRIPTION
The grpc/grpc repo split their template into one-per-language, so there's not a single clear link to replace it with. Replace the mention of the template with a reminder that we need to know what language is impacted. But otherwise it seems the only practical thing is to trust they will send detailed enough information or respond when we ask for additional details.