### PR TITLE
L105: Python Add New Error Types

### DIFF
--- a/L105-python-expose-new-error-types.md
+++ b/L105-python-expose-new-error-types.md
@@ -4,8 +4,8 @@ L105: Python Add New Error Types
 * Approver: gnossen
 * Status: In Review
 * Implemented in: Python
-* Last updated: 08/21/2023
-* Discussion at: TODO
+* Last updated: 08/31/2023
+* Discussion at: https://groups.google.com/g/grpc-io/c/pG34X9nAa3c
 
 ## Abstract
 

--- a/L105-python-expose-new-error-types.md
+++ b/L105-python-expose-new-error-types.md
@@ -10,8 +10,8 @@ L105: Python Add New Error Types
 ## Abstract
 
 Add two new errors in grpc public API:
-  * SyncBaseError
-  * SyncAbortError
+  * BaseError
+  * AbortError
 
 ## Background
 
@@ -19,11 +19,11 @@ In case of abort, currently we don't log anything, exposing those error types al
 
 ## Proposal
 
-Add SyncAbortError and SyncBaseError in public API.
+Add AbortError and BaseError in public API.
 
 ## Rationale
 
-The Async API [has similar errors](https://github.com/grpc/grpc/blob/v1.57.x/src/python/grpcio/grpc/aio/__init__.py#L23,L24). Adding them to the Sync API will help us keep the two stacks in sync and allow users of the Sync implementation to catch and handle aborts.
+The Async API [has similar errors](https://github.com/grpc/grpc/blob/v1.57.x/src/python/grpcio/grpc/aio/__init__.py#L23,L24). We're refactoring code so those errors will also be used in Sync API. Adding them to the Sync API will help us keep the two stacks in sync and allow users of the Sync implementation to catch and handle aborts.
 
 ## Implementation
 

--- a/L105-python-expose-new-error-types.md
+++ b/L105-python-expose-new-error-types.md
@@ -1,0 +1,30 @@
+L105: Python Add New Error Types
+----
+* Author(s): XuanWang-Amos
+* Approver: gnossen
+* Status: In Review
+* Implemented in: Python
+* Last updated: 08/21/2023
+* Discussion at: TODO
+
+## Abstract
+
+Add two new errors in grpc public API:
+  * SyncBaseError
+  * SyncAbortError
+
+## Background
+
+In case of abort, currently we don't log anything, exposing those error types allows user to catch and handle aborts if they want.
+
+## Proposal
+
+Add SyncAbortError and SyncBaseError in public API.
+
+## Rationale
+
+The Async API [has similar errors](https://github.com/grpc/grpc/blob/v1.57.x/src/python/grpcio/grpc/aio/__init__.py#L23,L24). Adding them to the Sync API will help us keep the two stacks in sync and allow users of the Sync implementation to catch and handle aborts.
+
+## Implementation
+
+And and check AbortError while abort : https://github.com/grpc/grpc/pull/33969

--- a/L105-python-expose-new-error-types.md
+++ b/L105-python-expose-new-error-types.md
@@ -9,9 +9,10 @@ L105: Python Add New Error Types
 
 ## Abstract
 
-Add two new errors in grpc public API:
+* Add two new errors in grpc public API:
   * BaseError
   * AbortError
+* Also changed RpcError to be a subclass of BaseError.
 
 ## Background
 
@@ -19,11 +20,22 @@ In case of abort, currently we don't log anything, exposing those error types al
 
 ## Proposal
 
-Add AbortError and BaseError in public API.
+1. Add AbortError and BaseError in public API.
+2. Change RpcError to be a subclass of BaseError.
+
 
 ## Rationale
 
 The Async API [has similar errors](https://github.com/grpc/grpc/blob/v1.57.x/src/python/grpcio/grpc/aio/__init__.py#L23,L24). We're refactoring code so those errors will also be used in Sync API. Adding them to the Sync API will help us keep the two stacks in sync and allow users of the Sync implementation to catch and handle aborts.
+
+We also plan to change RpcError to be a subclass of BaseError so that all grpc errors are a subclass of BaseError, this will allow users to catching all gRPC exceptions use code like this:
+
+```Python
+try:
+  do_grpc_stuff()
+except grpc.BaseError as e:
+  # handle error
+```
 
 ## Implementation
 


### PR DESCRIPTION
Add two new errors in grpc public API.
Discussion thread: https://groups.google.com/g/grpc-io/c/pG34X9nAa3c