### PR TITLE
Update Go OTel API

### DIFF
--- a/A66-otel-stats.md
+++ b/A66-otel-stats.md
@@ -249,7 +249,8 @@ type MetricsOptions struct {
   TargetAttributeFilter func(string) bool
   // MethodAttributeFilter is a callback that takes the method string and
   // returns a bool representing whether to use method as a label value or use
-  // the string "other". If unset, will use the method string as is.
+  // the string "other". If unset, will use the method string as is. This is
+  // used only for generic methods, and not registered methods.
   MethodAttributeFilter func(string) bool
 }
 

--- a/A66-otel-stats.md
+++ b/A66-otel-stats.md
@@ -243,6 +243,14 @@ type MetricsOptions struct {
   // to Named Meter instances to instrument an application. To enable metrics
   // collection, set a meter provider. If unset, no metrics will be recorded.
   MeterProvider metric.MeterProvider
+  // TargetAttributeFilter is a callback that takes the target string and
+  // returns a bool representing whether to use target as a label value or use
+  // the string "other". If unset, will use the target string as is.
+  TargetAttributeFilter func(string) bool
+  // MethodAttributeFilter is a callback that takes the method string and
+  // returns a bool representing whether to use method as a label value or use
+  // the string "other". If unset, will use the method string as is.
+  MethodAttributeFilter func(string) bool
 }
 
 // DialOption returns a dial option which enables OpenTelemetry instrumentation


### PR DESCRIPTION
This PR adds target and method label value filtration as part of the knobs provided to users for the grpc-go Open Telemetry component.