### PR TITLE
A47 update: fix spec for data plane authority

### DIFF
--- a/A47-xds-federation.md
+++ b/A47-xds-federation.md
@@ -4,7 +4,7 @@ A47: xDS Federation
 * Approver: @ejona86, @dfawley
 * Status: Implemented
 * Implemented in: C++
-* Last updated: 2022-02-22
+* Last updated: 2024-02-22
 * Discussion at: https://groups.google.com/g/grpc-io/c/17pQyP31yL8
 
 ## Abstract
@@ -104,7 +104,8 @@ Note that the authority used for the data plane connections (which is
 also used to select the VirtualHost within the xDS RouteConfiguration)
 will continue to be the path component of the `xds` URI used to create the
 gRPC channel, stripping off the leading `/` if any.  (Any remaining `/`
-characters will be percent-encoded, as is normal for gRPC target URIs.)
+characters will be percent-encoded, as is normal when determining the
+data plane authority from the gRPC target URI.)
 
 ### Bootstrap Config Changes
 

--- a/A47-xds-federation.md
+++ b/A47-xds-federation.md
@@ -4,7 +4,7 @@ A47: xDS Federation
 * Approver: @ejona86, @dfawley
 * Status: Implemented
 * Implemented in: C++
-* Last updated: 2022-01-24
+* Last updated: 2022-02-22
 * Discussion at: https://groups.google.com/g/grpc-io/c/17pQyP31yL8
 
 ## Abstract
@@ -102,9 +102,9 @@ an optional authority in the `xds` URI.  The procedure for handling an
 
 Note that the authority used for the data plane connections (which is
 also used to select the VirtualHost within the xDS RouteConfiguration)
-will continue to be the last path component of the `xds` URI used to
-create the gRPC channel (i.e., the part following the last `/` character, or
-the entire path if the path contains no `/` character).
+will continue to be the path component of the `xds` URI used to create the
+gRPC channel, stripping off the leading `/` if any.  (Any remaining `/`
+characters will be percent-encoded, as is normal for gRPC target URIs.)
 
 ### Bootstrap Config Changes
 


### PR DESCRIPTION
We decided on this behavior a while ago, but it looks like we forgot to update the gRFC.