### PR TITLE
L117: C-core: replace gpr logging with absl logging. Marking as final.

### DIFF
--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -3,7 +3,7 @@ L117: C-core: Replace gpr Logging with absl Logging
 
 * Author(s): @tanvi-jagtap
 * Approver: @markdroth , @ctiller
-* Status: In Review 
+* Status: Final
 * Implemented in: gRPC C++
 * Last updated: 2024-05-07.
 * Discussion at: https://groups.google.com/g/grpc-io/c/Jg7bvHqAyCU


### PR DESCRIPTION
L117: C-core: replace gpr logging with absl logging.
Marking as final.