### PR TITLE
L117 update: Remove stack trace flag

### DIFF
--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -49,6 +49,7 @@ We are proposing to remove all instances of gpr logging and asserts and replace 
 ### Functions that will be removed 
 * `gpr_log_severity_string` - This wont be needed anymore. 
 * `gpr_should_log` - This wont be needed anymore. 
+* `GRPC_STACKTRACE_MINLOGLEVEL` - This will not be needed anymore.
 
 ### Will work similar to before
 * `GRPC_VERBOSITY` will work as follows

--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -77,7 +77,8 @@ void SomeInitFunctionCalledByGrpcInit() {
   } else {
     VLOG(2) << "No verbosity set.";
   }
-}```
+}
+```
 
 ## Rationale
 

--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -55,24 +55,24 @@ We are proposing to remove all instances of gpr logging and asserts and replace 
 * `GRPC_VERBOSITY` will work as follows
 
 ```
-void SomeInitFunctionCalledByGrpcInit() {
-  absl::optional<std::string> verbosity = grpc_core::GetEnv("GRPC_VERBOSITY");
-  if (verbosity.has_value()) {
-    VLOG(2) << "Log verbosity: " << verbosity.value();
-    if (absl::EqualsIgnoreCase(verbosity.value(), "INFO")) {
-      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
-    } else if (absl::EqualsIgnoreCase(verbosity.value(), "ERROR")) {
-      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kError);
-    } else if (absl::EqualsIgnoreCase(verbosity.value(), "WARNING")) {
-      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kWarning);
-    } else if (absl::EqualsIgnoreCase(verbosity.value(), "DEBUG")) {
-      absl::SetGlobalVLogLevel(2);
-      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
-    } else {
-      LOG(ERROR) << "Unknown log verbosity: " << verbosity.value();
-    }
+void gpr_log_verbosity_init() {
+  absl::string_view verbosity = grpc_core::ConfigVars::Get().Verbosity();
+  if (absl::EqualsIgnoreCase(verbosity, "INFO")) {
+    absl::SetVLogLevel("*grpc*/*", -1);
+    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
+  } else if (absl::EqualsIgnoreCase(verbosity, "DEBUG")) {
+    absl::SetVLogLevel("*grpc*/*", 2);
+    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
+  } else if (absl::EqualsIgnoreCase(verbosity, "ERROR")) {
+    absl::SetVLogLevel("*grpc*/*", -1);
+    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kError);
+  } else if (absl::EqualsIgnoreCase(verbosity, "NONE")) {
+    absl::SetVLogLevel("*grpc*/*", -1);
+    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
+  } else if (verbosity.empty()) {
+    // Do not alter absl settings if GRPC_VERBOSITY flag is not set.
   } else {
-    VLOG(2) << "No verbosity set. Default will be used.";
+    LOG(ERROR) << "Unknown log verbosity: " << verbosity;
   }
 }
 ```

--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -55,27 +55,29 @@ We are proposing to remove all instances of gpr logging and asserts and replace 
 * `GRPC_VERBOSITY` will work as follows
 
 ```
-void gpr_log_verbosity_init() {
-  absl::string_view verbosity = grpc_core::ConfigVars::Get().Verbosity();
-  if (absl::EqualsIgnoreCase(verbosity, "INFO")) {
-    absl::SetVLogLevel("*grpc*/*", -1);
-    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
-  } else if (absl::EqualsIgnoreCase(verbosity, "DEBUG")) {
-    absl::SetVLogLevel("*grpc*/*", 2);
-    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
-  } else if (absl::EqualsIgnoreCase(verbosity, "ERROR")) {
-    absl::SetVLogLevel("*grpc*/*", -1);
-    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kError);
-  } else if (absl::EqualsIgnoreCase(verbosity, "NONE")) {
-    absl::SetVLogLevel("*grpc*/*", -1);
-    absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfinity);
-  } else if (verbosity.empty()) {
-    // Do not alter absl settings if GRPC_VERBOSITY flag is not set.
+void SomeInitFunctionCalledByGrpcInit() {
+  absl::optional<std::string> verbosity = grpc_core::GetEnv("GRPC_VERBOSITY");
+  if (verbosity.has_value()) {
+    VLOG(2) << "Log verbosity: " << verbosity.value();
+    if (absl::EqualsIgnoreCase(verbosity.value(), "INFO")) {
+      absl::SetVLogLevel("*grpc*/*", -1);
+      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
+    } else if (absl::EqualsIgnoreCase(verbosity.value(), "ERROR")) {
+      absl::SetVLogLevel("*grpc*/*", -1);
+      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kError);
+    } else if (absl::EqualsIgnoreCase(verbosity.value(), "WARNING")) {
+      absl::SetVLogLevel("*grpc*/*", -1);
+      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kWarning);
+    } else if (absl::EqualsIgnoreCase(verbosity.value(), "DEBUG")) {
+      absl::SetGlobalVLogLevel(2);
+      absl::SetMinLogLevel(absl::LogSeverityAtLeast::kInfo);
+    } else {
+      // Do not alter absl settings if GRPC_VERBOSITY flag is not set.
+    }
   } else {
-    LOG(ERROR) << "Unknown log verbosity: " << verbosity;
+    VLOG(2) << "No verbosity set.";
   }
-}
-```
+}```
 
 ## Rationale
 

--- a/L117-core-replace-gpr-logging-with-abseil-logging.md
+++ b/L117-core-replace-gpr-logging-with-abseil-logging.md
@@ -46,7 +46,7 @@ We are proposing to remove all instances of gpr logging and asserts and replace 
 * `gpr_set_log_function` - This function will be removed. Teams can consider usage of [LogSink](https://github.com/abseil/abseil-cpp/blob/fa57bfc573453d57a38552eedcce894b0e2d9f5e/absl/log/log_sink.h) and [AddLogSink](https://github.com/abseil/abseil-cpp/blob/fa57bfc573453d57a38552eedcce894b0e2d9f5e/absl/log/log_sink_registry.h).
 * `gpr_set_log_verbosity` will be removed. 
 
-### Functions that will be removed 
+### Flags and Functions that will be removed 
 * `gpr_log_severity_string` - This wont be needed anymore. 
 * `gpr_should_log` - This wont be needed anymore. 
 * `GRPC_STACKTRACE_MINLOGLEVEL` - This will not be needed anymore.


### PR DESCRIPTION
- Remove stack trace flag.
- Updating the pseudo code to include the SetVLogLevel calls.
- https://github.com/grpc/grpc/blob/master/src/core/util/log.cc