### PR TITLE
A74 update: improve XdsDependencyManager watcher API

### DIFF
--- a/A74-xds-config-tears.md
+++ b/A74-xds-config-tears.md
@@ -210,7 +210,7 @@ the following cases:
   *did* previously see OnResourceChanged(), then the OnError() event is
   ignored by the XdsDependencyManager and not passed on to the xds
   resolver.)
-- When the received listener resource is a socket listner instead of an
+- When the received listener resource is a socket listener instead of an
   API listener.
 - When the received route configuration does not contain a virtual host
   matching the channel's default authority.


### PR DESCRIPTION
The original intent here was that the xds resolver would handle `OnError()` the same way that it did prior to A74: it would return a result to the channel that had an error for the service config, which would cause the channel to ignore the update if it had already previously seen a valid result.  This poses a problem for cases like receiving a socket listener instead of an API listener or receiving a route config that does not contain a virtual host matching the channel's default authority, because in those cases we want to stop using the previously seen resources and start failing data plane RPCs.

This change fixes that by specifying that the xds resolver will see errors only in cases where we want to stop using the previously received resources, if any.  As a result, we are able to collapse all three methods on the watcher into one.