### PR TITLE
A50: Exclude locally-initiated client cancellations from Call Counter (#12923)

### DIFF
--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -284,7 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Locally-Initiated Client-Side Cancellations
 
-Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (`hedging cancellations` of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and implementation-wise it is much simpler to handle `DEADLINE_EXCEEDED` identically to cancellation, gRPC treats it as a client-side cancellation.
+Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (`hedging cancellations` of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and because a deadline expiration cannot be definitively attributed to a server failure rather than a network delay, gRPC treats it as a client-side cancellation.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -137,7 +137,7 @@ When the `outlier_detection` LB policy receives an address update, it will creat
 
 When the child policy asks for a subchannel, the `outlier_detection` will wrap the subchannel with a wrapper (see [Subchannel Wrapper section](#subchannel-wrapper)). Then, the subchannel wrapper will be added to the list in the map entry for its address, if that map entry exists. If there is no map entry, or if the subchannel is created with multiple addresses, the subchannel will be ignored for outlier detection. If that address is currently ejected, that subchannel wrapper's `eject` method will be called.
 
-The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
+The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, updates the counter in the map entry referenced by the subchannel wrapper that was picked. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
 
 The `outlier_detection` LB policy will have a timer that triggers on a period determined by the `interval` config option, and does the following:
 
@@ -170,7 +170,7 @@ To un-eject an address, set the current ejection timestamp to `null` and call `u
 
 ### Call Counter
 
-This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
+This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes, and another counting failures. The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
 
 ### Subchannel Wrapper
 
@@ -284,7 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Locally-Initiated Client-Side Cancellations
 
-Locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (hedging cancellations of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and because a deadline expiration cannot be definitively attributed to a server failure rather than a network delay, gRPC treats it as a client-side cancellation.
+Locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded) are excluded from outlier detection counting. For locally-initiated cancellations (hedging cancellations of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For deadline exceeded, this differs from Envoy (which counts deadline expirations as failures for outlier detection). In gRPC, client-side deadline expiration cannot be reliably distinguished from other client cancellations cross-language, and a deadline expiration cannot be definitively attributed to a server failure rather than a network or client-side delay. Therefore, gRPC treats client-side deadline expiration as a locally-initiated cancellation and excludes it from outlier detection counting.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -170,7 +170,7 @@ To un-eject an address, set the current ejection timestamp to `null` and call `u
 
 ### Call Counter
 
-This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes, and another counting failures. The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
+This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes, and another counting failures. The active bucket is updated each time a call finishes, excluding client-initiated cancellations (such as application cancellations, cancellations of non-winning hedged attempts, etc.) and client-side deadline expirations. When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
 
 ### Subchannel Wrapper
 
@@ -282,9 +282,13 @@ Envoy's specification of outlier detection includes the ejection criteria Consec
 
 Envoy defines some errors as "external" and some as "local origin", and their specification of outlier detection allows separate configurations for handling each of them. gRPC does not separate errors that way, so there is no way to split them like that and handle those two categories separately.
 
-### Excluding Locally-Initiated Client-Side Cancellations
+### Excluding Client-Initiated Cancellations and Deadline Expirations
 
-Locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded) are excluded from outlier detection counting. For locally-initiated cancellations (hedging cancellations of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For deadline exceeded, this differs from Envoy (which counts deadline expirations as failures for outlier detection). In gRPC, client-side deadline expiration cannot be reliably distinguished from other client cancellations cross-language, and a deadline expiration cannot be definitively attributed to a server failure rather than a network or client-side delay. Therefore, gRPC treats client-side deadline expiration as a locally-initiated cancellation and excludes it from outlier detection counting.
+Client-initiated cancellations (such as application cancellations, cancellations of non-winning hedged attempts, etc.) and client-side deadline expirations are excluded from outlier detection counting.
+
+Excluding client cancellations aligns with Envoy's `resetStream()` behavior and prevents false-positive endpoint ejections when hedging is enabled.
+
+Excluding client-side deadline expirations differs from Envoy, which counts timeouts as failures for outlier detection. However, in gRPC, client-side deadline expirations cannot be reliably distinguished from other client-initiated cancellations cross-language, and a deadline expiration cannot be definitively attributed to an endpoint failure rather than client-side or network delays. Therefore, client-side deadline expirations are treated identically to client cancellations and excluded from outlier detection counting.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -137,7 +137,7 @@ When the `outlier_detection` LB policy receives an address update, it will creat
 
 When the child policy asks for a subchannel, the `outlier_detection` will wrap the subchannel with a wrapper (see [Subchannel Wrapper section](#subchannel-wrapper)). Then, the subchannel wrapper will be added to the list in the map entry for its address, if that map entry exists. If there is no map entry, or if the subchannel is created with multiple addresses, the subchannel will be ignored for outlier detection. If that address is currently ejected, that subchannel wrapper's `eject` method will be called.
 
-The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
+The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
 
 The `outlier_detection` LB policy will have a timer that triggers on a period determined by the `interval` config option, and does the following:
 
@@ -170,7 +170,7 @@ To un-eject an address, set the current ejection timestamp to `null` and call `u
 
 ### Call Counter
 
-This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes, and another counting failures. The active bucket is updated each time a call finishes. When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
+This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
 
 ### Subchannel Wrapper
 
@@ -281,6 +281,10 @@ Envoy's specification of outlier detection includes the ejection criteria Consec
 ### Splitting External and Local Origin errors
 
 Envoy defines some errors as "external" and some as "local origin", and their specification of outlier detection allows separate configurations for handling each of them. gRPC does not separate errors that way, so there is no way to split them like that and handle those two categories separately.
+
+### Excluding Locally-Initiated Client-Side Cancellations
+
+Locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). This aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -284,11 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Client-Initiated Cancellations and Deadline Expirations
 
-Client-initiated cancellations (such as application cancellations, cancellations of non-winning hedged attempts, etc.) and client-side deadline expirations are excluded from outlier detection counting.
-
-Excluding client cancellations aligns with Envoy's `resetStream()` behavior and prevents false-positive endpoint ejections when hedging is enabled.
-
-Excluding client-side deadline expirations differs from Envoy, which counts timeouts as failures for outlier detection. However, in gRPC, client-side deadline expirations cannot be reliably distinguished from other client-initiated cancellations cross-language, and a deadline expiration cannot be definitively attributed to an endpoint failure rather than client-side or network delays. Therefore, client-side deadline expirations are treated identically to client cancellations and excluded from outlier detection counting.
+Client-initiated cancellations (such as application cancellations, cancellations of non-winning hedged attempts, etc.) and client-side deadline expirations are excluded from outlier detection counting. Excluding client cancellations aligns with Envoy's `resetStream()` behavior and prevents false-positive endpoint ejections when hedging is enabled. Excluding client-side deadline expirations differs from Envoy, which counts timeouts as failures for outlier detection. However, in gRPC, client-side deadline expirations cannot be reliably distinguished from other client-initiated cancellations cross-language, and a deadline expiration cannot be definitively attributed to an endpoint failure rather than client-side or network delays. Therefore, client-side deadline expirations are treated identically to client cancellations and excluded from outlier detection counting.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -137,7 +137,7 @@ When the `outlier_detection` LB policy receives an address update, it will creat
 
 When the child policy asks for a subchannel, the `outlier_detection` will wrap the subchannel with a wrapper (see [Subchannel Wrapper section](#subchannel-wrapper)). Then, the subchannel wrapper will be added to the list in the map entry for its address, if that map entry exists. If there is no map entry, or if the subchannel is created with multiple addresses, the subchannel will be ignored for outlier detection. If that address is currently ejected, that subchannel wrapper's `eject` method will be called.
 
-The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
+The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
 
 The `outlier_detection` LB policy will have a timer that triggers on a period determined by the `interval` config option, and does the following:
 
@@ -170,7 +170,7 @@ To un-eject an address, set the current ejection timestamp to `null` and call `u
 
 ### Call Counter
 
-This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
+This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
 
 ### Subchannel Wrapper
 
@@ -284,7 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Locally-Initiated Client-Side Cancellations
 
-Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (`hedging cancellations` of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and because a deadline expiration cannot be definitively attributed to a server failure rather than a network delay, gRPC treats it as a client-side cancellation.
+Locally-initiated client-side cancellations (hedging cancellations, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (hedging cancellations of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and because a deadline expiration cannot be definitively attributed to a server failure rather than a network delay, gRPC treats it as a client-side cancellation.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -137,7 +137,7 @@ When the `outlier_detection` LB policy receives an address update, it will creat
 
 When the child policy asks for a subchannel, the `outlier_detection` will wrap the subchannel with a wrapper (see [Subchannel Wrapper section](#subchannel-wrapper)). Then, the subchannel wrapper will be added to the list in the map entry for its address, if that map entry exists. If there is no map entry, or if the subchannel is created with multiple addresses, the subchannel will be ignored for outlier detection. If that address is currently ejected, that subchannel wrapper's `eject` method will be called.
 
-The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
+The `outlier_detection` LB policy will provide a picker that delegates to the child policy's picker, and when the request finishes, increment the corresponding counter in the map entry referenced by the subchannel wrapper that was picked. Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) MUST be excluded from `successCount` and `failureCount`. If both the `success_rate_ejection` and `failure_percentage_ejection` fields are unset in the configuration, the picker should not do that counting.
 
 The `outlier_detection` LB policy will have a timer that triggers on a period determined by the `interval` config option, and does the following:
 
@@ -170,7 +170,7 @@ To un-eject an address, set the current ejection timestamp to `null` and call `u
 
 ### Call Counter
 
-This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
+This design is based directly on Envoy's implementation. The object contains two buckets, and each bucket has a number counting successes (`successCount`), and another counting failures (`failureCount`). The active bucket is updated each time a call finishes, excluding locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`). When the timer triggers, the inactive bucket is zeroed and swapped with the active bucket. Then the inactive bucket contains the number of successes and failures since the last time the timer triggered. Those numbers are used to evaluate the ejection criteria.
 
 ### Subchannel Wrapper
 
@@ -284,7 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Locally-Initiated Client-Side Cancellations
 
-Locally-initiated client-side cancellations (`hedging cancellations`, `application CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). This aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging.
+Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). Although `DEADLINE_EXCEEDED` could be argued as an endpoint or network issue, implementation-wise it is treated as a client-side cancellation. This aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging.
 
 ### Map Entry Source
 

--- a/A50-xds-outlier-detection.md
+++ b/A50-xds-outlier-detection.md
@@ -284,7 +284,7 @@ Envoy defines some errors as "external" and some as "local origin", and their sp
 
 ### Excluding Locally-Initiated Client-Side Cancellations
 
-Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). Although `DEADLINE_EXCEEDED` could be argued as an endpoint or network issue, implementation-wise it is treated as a client-side cancellation. This aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging.
+Locally-initiated client-side cancellations (`hedging cancellations`, application `CANCELLED`, and `DEADLINE_EXCEEDED`) are excluded from outlier detection counting (`successCount` and `failureCount`). For locally-initiated cancellations (`hedging cancellations` of non-winning sibling attempts and application-initiated cancellations), this aligns with Envoy's `resetStream()` behavior and prevents false-positive ejections during hedging. For `DEADLINE_EXCEEDED`, this differs from Envoy (which counts deadline expirations as failures for outlier detection); however, because deadline expiration semantics vary between Envoy and gRPC, and implementation-wise it is much simpler to handle `DEADLINE_EXCEEDED` identically to cancellation, gRPC treats it as a client-side cancellation.
 
 ### Map Entry Source
 


### PR DESCRIPTION
## Summary
Clarifies gRFC A50 (`A50-xds-outlier-detection.md`) to explicitly specify that locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded) are excluded from the Outlier Detection Call Counter.

## Key Clarifications
1. **Picker**: Updates the counter in the map entry on request completion.
2. **Call Counter**: Specifies that the active bucket tracks successes and failures while excluding locally-initiated client-side cancellations (hedging cancellations, application cancellation, and deadline exceeded etc).
3. **Rationale**:
   - **Hedging & Application Cancellations**: Align with Envoy's `resetStream()` behavior (silently resetting the stream without recording endpoint errors), preventing false-positive ejections during hedging.
   - **Deadline Exceeded**: Differs from Envoy (which counts timeouts as failures for outlier detection). In gRPC, client-side deadline expiration cannot be reliably distinguished from other client cancellations cross-language, and client timeouts cannot be definitively attributed to an endpoint failure rather than network or client-side delays.

## Related Work
- gRPC-Java PR #12923: https://github.com/grpc/grpc-java/pull/12923/changes
- Envoy Outlier Detection: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier